### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/wine_cellar/react/maps/ItemPopup.jsx
+++ b/wine_cellar/react/maps/ItemPopup.jsx
@@ -36,7 +36,7 @@ const sanitizeImageSrc = (value) => {
     // If value is absolute, check protocol explicitly.
     const url = new URL(trimmed, window.location.origin)
     if (url.protocol === 'http:' || url.protocol === 'https:') {
-      return trimmed
+      return url.href
     }
     // For other protocols, do not use the value.
     return undefined


### PR DESCRIPTION
Potential fix for [https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/1](https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/1)

In general, the fix is to ensure that any data flowing from untrusted DOM text into an attribute that can trigger browser navigation or resource loading (like `src` or `href`) is validated and constrained to a safe scheme and shape before being used. Instead of inserting the tainted value directly into the JSX, we derive a sanitized value that only allows trusted URL schemes (e.g. `http`, `https`, maybe relative URLs), and falls back to a safe placeholder if validation fails.

For this specific code, the best minimal fix is to introduce a small helper inside `ItemPopup.jsx` that validates `feature.properties.image` and only uses it if it is an HTTP(S) or relative URL. We then pass the sanitized value to the `src` attribute. This keeps existing behavior for normal URLs but prevents potentially dangerous ones (e.g. `javascript:` or other unexpected schemes) from being used. We do not need new imports; we can use the built‑in `URL` constructor to parse and check schemes, with a fallback for relative paths. The concrete changes are all within `ItemPopup.jsx`: add a `sanitizeImageSrc` function above `ItemPopup`, compute `const imageSrc = sanitizeImageSrc(feature.properties.image)` inside `ItemPopup`, and use `imageSrc` in the `<img>` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
