### PR TITLE
Potential fix for code scanning alert no. 19: Information exposure through an exception

### DIFF
--- a/wine_cellar/apps/wine/views.py
+++ b/wine_cellar/apps/wine/views.py
@@ -1888,13 +1888,18 @@ def crop_wine_image(request, pk):
             }
         )
     except (json.JSONDecodeError, ValueError) as e:
-        return JsonResponse({"error": str(e)}, status=400)
+        # Return a generic error message to avoid exposing internal details
+        return JsonResponse({"error": "Invalid request data"}, status=400)
     except Exception as e:
         import logging
 
         logger = logging.getLogger(__name__)
         logger.exception("Error cropping image")
-        return JsonResponse({"error": str(e)}, status=500)
+        # Do not expose the raw exception message to the client
+        return JsonResponse(
+            {"error": "An internal error occurred while processing the image."},
+            status=500,
+        )
 
 
 class SaleAlertsView(TemplateView):


### PR DESCRIPTION
Potential fix for [https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/19](https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/19)

In general, the fix is to avoid sending raw exception messages (or any stack trace information) to the client. Instead, log the exception on the server (including stack trace) and return a generic, user-friendly error message to the client. For client-side input errors (like invalid JSON), you can return a stable, non-sensitive message such as “Invalid request data” without including `str(e)`.

Specifically for `crop_wine_image` in `wine_cellar/apps/wine/views.py`:

- For the `except (json.JSONDecodeError, ValueError) as e:` block at line 1890, replace the response body to use a generic message like `{"error": "Invalid request data"}` instead of `{"error": str(e)}`. You can still log the detailed exception if desired, but the client should not see it.
- For the `except Exception as e:` block at line 1892, keep logging the exception (including stack trace) using `logger.exception("Error cropping image")`, but change the JSON response to a generic message like `{"error": "An internal error has occurred while processing the image."}` instead of `{"error": str(e)}`.

No new imports are strictly required because the generic messages are simple literals, and you already import `logging` locally in the generic `Exception` block. All behavior (crop logic, status codes, etc.) remains the same, only the exposed error content is changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
