### PR TITLE
Potential fix for code scanning alert no. 14: Information exposure through an exception

### DIFF
--- a/wine_cellar/apps/hardware/views.py
+++ b/wine_cellar/apps/hardware/views.py
@@ -491,9 +491,16 @@ def sync_operations(request):
                 offline_op.save(update_fields=["applied"])
                 results.append({"id": offline_op.pk, "success": True})
             except Exception as e:
+                # Store detailed error server-side, but do not expose it to the client
                 offline_op.error = str(e)
                 offline_op.save(update_fields=["error"])
-                results.append({"id": offline_op.pk, "success": False, "error": str(e)})
+                results.append(
+                    {
+                        "id": offline_op.pk,
+                        "success": False,
+                        "error": "Failed to apply operation",
+                    }
+                )
 
         return JsonResponse(
             {


### PR DESCRIPTION
Potential fix for [https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/14](https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/14)

To fix the issue, we should stop including the raw exception message (`str(e)`) in the API response, and instead return a generic, non-sensitive error indication to the client. At the same time, we can keep the current behavior of storing the detailed error string in `offline_op.error`, so developers still have access to it on the server side for debugging.

Concretely, in `wine_cellar/apps/hardware/views.py`, inside the `sync_operations` view, we will:
- Keep `offline_op.error = str(e)` and the corresponding `save(update_fields=["error"])` to preserve server-side error logging.
- Change the `results.append(...)` call in the `except Exception as e:` block so that the `error` value returned to the client is a generic message (for example `"Failed to apply operation"`), and does not include `str(e)` or any part of the stack trace/exception message.
- Optionally, we can also include some non-sensitive context such as the operation type in the generic message, but we must not leak the exception content itself.

No new imports or helper methods are required; the change is a small edit confined to the `except` block in `sync_operations`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
