### PR TITLE
Potential fix for code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/wine_cellar/apps/storage/views.py
+++ b/wine_cellar/apps/storage/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.contrib.auth.decorators import login_required
 from django.db import models
@@ -21,6 +22,9 @@ from wine_cellar.apps.storage.forms import (
 from wine_cellar.apps.storage.models import Storage, StorageItem
 from wine_cellar.apps.user.views import get_active_household
 from wine_cellar.apps.wine.models import Wine
+
+
+logger = logging.getLogger(__name__)
 
 
 class StorageListView(ListView):
@@ -528,8 +532,12 @@ def move_bottle(request):
 
     except json.JSONDecodeError:
         return JsonResponse({"error": "Invalid JSON"}, status=400)
-    except Exception as e:
-        return JsonResponse({"error": str(e)}, status=500)
+    except Exception:
+        logger.exception("Unexpected error while moving bottle.")
+        return JsonResponse(
+            {"error": "An internal error occurred while moving the bottle."},
+            status=500,
+        )
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/15](https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/15)

In general, to fix this issue we should avoid returning raw exception messages (or stack traces) to the client. Instead, we should log the exception on the server and return a generic error message that does not reveal internal details. This preserves current functionality (client still receives an error response with HTTP 500) but removes the information leak.

Concretely, in `wine_cellar/apps/storage/views.py` inside the `move_bottle` view, we should change the broad `except Exception as e:` clause to log the exception and respond with a generic message such as `"An internal error occurred."` rather than `str(e)`. To log the exception, we can use Python’s standard `logging` module and call `logger.exception(...)`, which will include the stack trace in server logs without exposing it to the user. This requires adding a logger at the top of the file (e.g., `logger = logging.getLogger(__name__)`) and importing `logging`. No other behavior of the view needs to change.

Specifically:
- Add `import logging` near the top of `views.py` and define `logger = logging.getLogger(__name__)`.
- Replace the `except Exception as e:` block at lines 531–532 with a block that uses `logger.exception` and returns a generic error JSON message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
