### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/wine_cellar/apps/wine/views.py
+++ b/wine_cellar/apps/wine/views.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 from decimal import Decimal
 from io import BytesIO
 
@@ -31,6 +32,8 @@ FINAL_FORM_STEP = 4
 
 # Maximum allowed image upload size (10MB) to prevent memory exhaustion
 MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10MB in bytes
+
+logger = logging.getLogger(__name__)
 
 
 def base64_to_uploaded_file(base64_data: str, filename: str) -> InMemoryUploadedFile:
@@ -1816,9 +1819,6 @@ def scan_barcode_ajax(request):
             )
 
     except Exception as e:
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.exception("Error in barcode scanning")
         return JsonResponse(
             {"error": "An internal error occurred while scanning the barcode."},


### PR DESCRIPTION
Potential fix for [https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/18](https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/18)

In general, the fix is to avoid returning raw exception messages (or stack traces) to clients. Instead, log the exception on the server, then return a generic, user-friendly error message (optionally with a non-sensitive error code) in the HTTP response.

For this specific case in `wine_cellar/apps/wine/views.py`, we should keep the existing logging inside the `except` block of `scan_barcode_ajax`, but change the JSON response so that it no longer includes `str(e)`. We can replace it with a generic message such as `"An internal error occurred while scanning the barcode."` or similar. This maintains existing functionality in terms of HTTP status (500) and the fact that an `"error"` key is present in the response, but removes the exposure of internal error details.

Concretely:
- Edit `scan_barcode_ajax` in `wine_cellar/apps/wine/views.py`.
- On line 1823, replace `JsonResponse({"error": str(e)}, status=500)` with a response using a static, non-sensitive message (e.g., `{"error": "Internal server error"}` or a more specific but still generic text).
- No new imports or helper methods are needed; the module already imports `JsonResponse`, and logging is already set up inside the `except` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
