### PR TITLE
Potential fix for code scanning alert no. 42: URL redirection from remote source

### DIFF
--- a/wine_cellar/apps/household/views.py
+++ b/wine_cellar/apps/household/views.py
@@ -233,8 +233,9 @@ class HouseholdSwitchView(LoginRequiredMixin, View):
         else:
             messages.error(request, _("Unable to switch household."))
 
-        # Redirect to referring page or home
-        next_url = request.POST.get("next", "/")
+        # Redirect to referring page or household list as a safe default
+        safe_default_url = reverse("household-list")
+        next_url = (request.POST.get("next") or "").strip()
         if url_has_allowed_host_and_scheme(
             url=next_url,
             allowed_hosts={request.get_host()},
@@ -242,7 +243,7 @@ class HouseholdSwitchView(LoginRequiredMixin, View):
         ):
             redirect_to = next_url
         else:
-            redirect_to = "/"
+            redirect_to = safe_default_url
         return redirect(redirect_to)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/42](https://github.com/jonhall145/wine-cellar-personal/security/code-scanning/42)

In general, to fix untrusted URL redirection you must ensure that any user-influenced redirect target is constrained to a safe set of destinations. In Django, the preferred pattern is to use `url_has_allowed_host_and_scheme` to ensure that the URL is relative or points only to allowed hosts, and then redirect only to such validated URLs, otherwise redirect to a safe internal page.

For this specific `HouseholdSwitchView.post` method in `wine_cellar/apps/household/views.py` (lines 215–246), the best fix with minimal functional change is:

- Keep using `url_has_allowed_host_and_scheme`, but:
  - Normalize `next_url` a bit (e.g., strip whitespace) so trivial malformed values can’t sneak through.
  - Use a named URL via `reverse("household-list")` or similar as the fallback instead of the hard-coded `"/"`, which is safer and clearer.
- Only ever call `redirect()` with a value that has either passed `url_has_allowed_host_and_scheme` or is this safe fallback.

This preserves existing behavior (redirect to the provided `next` when safe, otherwise go “home”), but makes the safety contract explicit and relies on well-known Django utilities (`url_has_allowed_host_and_scheme`, `reverse`), with no new dependencies.

Concretely:
- Adjust the `next_url` handling block at lines 237–246.
- Optionally introduce a `safe_default_url = reverse("household-list")` (or `"home"` if that exists) and use it in place of `"/"` both as the initial default in `request.POST.get` and as the fallback when validation fails.
- No new imports are required since `reverse` and `url_has_allowed_host_and_scheme` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
