### PR TITLE
add ghcr deploy make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ deploy:
 ghcr-deploy:
 	docker pull $(GHCR_IMAGE)
 	docker tag $(GHCR_IMAGE) wine-cellar:prod
-	$(PROD_COMPOSE) up -d wine-web whisky-web
+	$(PROD_COMPOSE) up -d --no-build --force-recreate --no-deps wine-web whisky-web
 	$(PROD_COMPOSE) restart nginx
 
 .PHONY: wine-deploy


### PR DESCRIPTION
## Summary
- add `GHCR_IMAGE` make variable defaulting to `ghcr.io/jonhall145/wine-cellar-personal:latest`
- add `make ghcr-deploy` to pull/tag/deploy from GHCR image
- add help text entry for the new deploy command

## Validation
- npx lint-staged
- make -n ghcr-deploy