### PR TITLE
fix: load react-vendors.js on wine and whisky map pages

### DIFF
--- a/wine_cellar/apps/whisky/templates/whisky/whisky_map.html
+++ b/wine_cellar/apps/whisky/templates/whisky/whisky_map.html
@@ -15,6 +15,7 @@
     </div>
 {% endblock content %}
 {% block extra_js %}
+    <script src="{% static 'react-vendors.js' %}"></script>
     <script src="{% static 'leaflet-vendors.js' %}"></script>
     <script src="{% static 'distillery_map.js' %}"></script>
 {% endblock extra_js %}

--- a/wine_cellar/apps/wine/templates/wine_map.html
+++ b/wine_cellar/apps/wine/templates/wine_map.html
@@ -13,6 +13,7 @@
     </div>
 {% endblock content %}
 {% block extra_js %}
+    <script src="{% static 'react-vendors.js' %}"></script>
     <script src="{% static 'leaflet-vendors.js' %}"></script>
     <script src="{% static 'maps.js' %}"></script>
 {% endblock extra_js %}


### PR DESCRIPTION
## Problem

Both `/wines/map/` and `/whiskies/map/` stopped rendering after commit `ee27945` added the `reactVendor` splitChunks group to webpack.

That config extracts React and ReactDOM into a separate `react-vendors.js` chunk, but neither map template was updated to load it. Without `react-vendors.js`, the map bundles have no React at runtime and the components silently fail to mount (caught by the ErrorBoundary).

## Fix

Add `<script src="{% static 'react-vendors.js' %}">` to both map templates, consistent with how other React pages (`label_scan.html`, `scan_whisky.html`) load it.

```
wine_map.html       + react-vendors.js
whisky_map.html     + react-vendors.js
```