### PR TITLE
switch media from docker volumes to USB bind mounts

### DIFF
--- a/backup_to_r2.sh
+++ b/backup_to_r2.sh
@@ -82,29 +82,17 @@ fi
 
 # ─── Media backup ────────────────────────────────────────────────────
 
-if [ "$MODE" = "docker" ]; then
-    # Extract media from Docker volume
-    echo "  Backing up media files from Docker volume..."
-    CONTAINER=$(docker compose -f "${PROJECT_DIR}/${COMPOSE_FILE}" ps -q wine-web 2>/dev/null | head -1)
-    if [ -n "$CONTAINER" ]; then
-        docker cp "${CONTAINER}:/app/media" "${TMP_DIR}/media" 2>/dev/null || true
-        if [ -d "${TMP_DIR}/media" ] && [ "$(ls -A "${TMP_DIR}/media" 2>/dev/null)" ]; then
-            tar czf "${TMP_DIR}/media_${TIMESTAMP}.tar.gz" -C "$TMP_DIR" media
-        fi
-    fi
+WINE_MEDIA="/mnt/usb/media/wine"
+WHISKY_MEDIA="/mnt/usb/media/whisky"
 
-    # Whisky media backup
-    echo "  Backing up whisky media files from Docker volume..."
-    WHISKY_CONTAINER=$(docker compose -f "${PROJECT_DIR}/${COMPOSE_FILE}" ps -q whisky-web 2>/dev/null | head -1)
-    if [ -n "$WHISKY_CONTAINER" ]; then
-        docker cp "${WHISKY_CONTAINER}:/app/media" "${TMP_DIR}/whisky_media" 2>/dev/null || true
-        if [ -d "${TMP_DIR}/whisky_media" ] && [ "$(ls -A "${TMP_DIR}/whisky_media" 2>/dev/null)" ]; then
-            tar czf "${TMP_DIR}/whisky_media_${TIMESTAMP}.tar.gz" -C "$TMP_DIR" whisky_media
-        fi
-    fi
-elif [ -d "$MEDIA_PATH" ]; then
-    echo "  Backing up media files..."
-    tar czf "${TMP_DIR}/media_${TIMESTAMP}.tar.gz" -C "$(dirname "$MEDIA_PATH")" "$(basename "$MEDIA_PATH")"
+if [ -d "$WINE_MEDIA" ] && [ "$(ls -A "$WINE_MEDIA" 2>/dev/null)" ]; then
+    echo "  Backing up wine media files..."
+    tar czf "${TMP_DIR}/media_${TIMESTAMP}.tar.gz" -C "$WINE_MEDIA" .
+fi
+
+if [ -d "$WHISKY_MEDIA" ] && [ "$(ls -A "$WHISKY_MEDIA" 2>/dev/null)" ]; then
+    echo "  Backing up whisky media files..."
+    tar czf "${TMP_DIR}/whisky_media_${TIMESTAMP}.tar.gz" -C "$WHISKY_MEDIA" .
 fi
 
 # ─── Upload to R2 ────────────────────────────────────────────────────

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@ services:
     env_file:
       - .env.docker.prod
     volumes:
-      - media_data:/app/media
+      - /mnt/usb/media/wine:/app/media
       - static_data:/app/staticfiles
     depends_on:
       db:
@@ -28,7 +28,7 @@ services:
     env_file:
       - .env.whisky.docker.prod
     volumes:
-      - whisky_media_data:/app/media
+      - /mnt/usb/media/whisky:/app/media
       - static_data:/app/staticfiles
     depends_on:
       db:
@@ -48,8 +48,8 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./ssl:/etc/nginx/ssl:ro
       - static_data:/app/staticfiles:ro
-      - media_data:/app/media:ro
-      - whisky_media_data:/app/whisky_media:ro
+      - /mnt/usb/media/wine:/app/media:ro
+      - /mnt/usb/media/whisky:/app/whisky_media:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:80/ || exit 1"]
       interval: 30s
@@ -87,7 +87,5 @@ services:
 
 volumes:
   postgres_prod_data:
-  media_data:
-  whisky_media_data:
   static_data:
   redis_data:


### PR DESCRIPTION
## Summary
- Replace Docker-managed volumes (`media_data`, `whisky_media_data`) with bind mounts to `/mnt/usb/media/wine` and `/mnt/usb/media/whisky` so media files persist reliably across deploys
- Update backup script to tar directly from USB paths instead of `docker cp` from containers

## Test plan
- [x] Verified wine-web, whisky-web, and nginx containers all see media files via bind mount
- [x] Verified all 210 wine images accessible (0 missing)
- [ ] Run a backup cycle to confirm `backup_to_r2.sh` still works with new paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)