### PR TITLE
feat: iOS Add to Home Screen hint in nav menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,7 +237,7 @@ This is a **mobile-first app**. Mobile testing is mandatory, not optional.
 - Verify bottle counts vs wine counts when filtering
 
 **Static Files & CSS:**
-- Changes to CSS/JS require `make watch` or `npm run build` to be visible
+- **NEVER run `npm run build` or `make watch` locally** — frontend assets are built inside the Docker image on GHCR. Local builds are unnecessary and should not be done.
 - Production requires `collectstatic` - handled automatically inside the Docker image build
 - Check browser cache / use incognito when CSS changes aren't visible
 

--- a/wine_cellar/assets/css/menu.css
+++ b/wine_cellar/assets/css/menu.css
@@ -187,6 +187,60 @@
   vertical-align: middle;
 }
 
+.ios-install-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+}
+
+.ios-install-modal[hidden] {
+  display: none;
+}
+
+.ios-install-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.ios-install-modal__sheet {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--white);
+  border-radius: 16px 16px 0 0;
+  padding: var(--spacing-xl) var(--spacing-xl) calc(var(--spacing-xl) + env(safe-area-inset-bottom));
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+}
+
+.ios-install-modal__close {
+  position: absolute;
+  top: var(--spacing-md);
+  right: var(--spacing-md);
+  background: none;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-color-gray);
+  padding: 4px 8px;
+}
+
+.ios-install-modal__title {
+  font-size: var(--font-lg);
+  font-weight: 600;
+  margin: 0 0 var(--spacing-md);
+  color: var(--darker-gray);
+}
+
+.ios-install-modal__body {
+  font-size: var(--font-md);
+  line-height: 1.6;
+  color: var(--text-color-gray);
+  margin: 0;
+}
+
 .settings-sidebar {
   margin-top: var(--spacing-xl);
   background-color: transparent;

--- a/wine_cellar/assets/js/pwa_sync.ts
+++ b/wine_cellar/assets/js/pwa_sync.ts
@@ -132,12 +132,40 @@ function updateOnlineStatus(banner: HTMLElement): void {
   }
 }
 
+function initIosInstallHint(): void {
+  const isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+  const isStandalone = ('standalone' in navigator) && (navigator as Navigator & { standalone: boolean }).standalone;
+  if (!isIos || isStandalone) return;
+
+  const menuItem = document.getElementById('ios-add-to-home-item');
+  const btn = document.getElementById('ios-add-to-home-btn');
+  const modal = document.getElementById('ios-install-modal') as HTMLElement | null;
+  if (!menuItem || !btn || !modal) return;
+
+  menuItem.style.display = '';
+
+  btn.addEventListener('click', () => {
+    modal.hidden = false;
+    // Close hamburger menu if open
+    const toggle = document.getElementById('menu-toggle') as HTMLInputElement | null;
+    if (toggle) toggle.checked = false;
+  });
+
+  modal.querySelector('.ios-install-modal__backdrop')?.addEventListener('click', () => {
+    modal.hidden = true;
+  });
+  modal.querySelector('.ios-install-modal__close')?.addEventListener('click', () => {
+    modal.hidden = true;
+  });
+}
+
 function init(): void {
   const banner = createOfflineBanner();
   const badge = createSyncBadge();
   updateOnlineStatus(banner);
   updateSyncBadge(badge);
   registerServiceWorker();
+  initIosInstallHint();
 
   window.addEventListener('online', async () => {
     updateOnlineStatus(banner);

--- a/wine_cellar/templates/base.html
+++ b/wine_cellar/templates/base.html
@@ -124,5 +124,18 @@
         </footer>
         <script src="{% static 'fontawesome-vendors.js' %}?v={% get_setting 'VERSION' %}" defer></script>
         <script src="{% static 'base.js' %}?v={% get_setting 'VERSION' %}" defer></script>
+        <div id="ios-install-modal" class="ios-install-modal" role="dialog" aria-modal="true" aria-label="Add to Home Screen" hidden>
+            <div class="ios-install-modal__backdrop"></div>
+            <div class="ios-install-modal__sheet">
+                <button class="ios-install-modal__close" type="button" aria-label="Close">&times;</button>
+                <p class="ios-install-modal__title">Add to Home Screen</p>
+                <p class="ios-install-modal__body">
+                    To install this app and remember camera permissions:<br><br>
+                    1. Tap the <strong>Share</strong> button <i class="fa-solid fa-arrow-up-from-bracket"></i> in Safari<br>
+                    2. Scroll down and tap <strong>Add to Home Screen</strong><br>
+                    3. Tap <strong>Add</strong>
+                </p>
+            </div>
+        </div>
     </body>
 </html>

--- a/wine_cellar/templates/includes/navigation_items.html
+++ b/wine_cellar/templates/includes/navigation_items.html
@@ -97,6 +97,11 @@
             </a>
         </li>
     {% endif %}
+    <li class="pure-menu-item" id="ios-add-to-home-item" style="display:none">
+        <button class="pure-menu-link button" type="button" id="ios-add-to-home-btn">
+            <i class="fa-solid fa-arrow-up-from-bracket"></i> Add to Home Screen
+        </button>
+    </li>
     <li class="pure-menu-item">
         <a href="{% url 'user-settings' %}" class="pure-menu-link">Settings</a>
     </li>


### PR DESCRIPTION
## Summary

- Adds an **Add to Home Screen** menu item that appears only on iOS Safari when the app is not already installed as a PWA
- Clicking it shows a bottom-sheet modal with step-by-step instructions (Share → Add to Home Screen → Add)
- When installed via home screen, iOS remembers camera permissions between sessions
- Updates CLAUDE.md to clarify that frontend assets must never be built locally — they are built inside the Docker image on GHCR

## Test plan

- [ ] On iOS Safari: open the hamburger menu and confirm "Add to Home Screen" item appears
- [ ] On desktop / non-iOS: confirm item is hidden
- [ ] Tap the item: confirm bottom-sheet modal appears with correct instructions
- [ ] Tap backdrop or ✕: confirm modal closes
- [ ] After adding to home screen (standalone mode): confirm item no longer appears in menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)