### PR TITLE
fix: capitalise APP_ITEM_NAME in headings

### DIFF
--- a/wine_cellar/templates/core/beverage_list.html
+++ b/wine_cellar/templates/core/beverage_list.html
@@ -5,7 +5,7 @@
     <script src="{% static 'tom_select.js' %}" type="module" defer></script>
 {% endblock extra_js %}
 {% block header %}
-    <h1 class="header__title">{{ APP_ITEM_NAME }} List</h1>
+    <h1 class="header__title">{{ APP_ITEM_NAME|capfirst }} List</h1>
 {% endblock header %}
 {% block content %}
     <div class="pure-g">

--- a/wine_cellar/templates/core/consumption_stats.html
+++ b/wine_cellar/templates/core/consumption_stats.html
@@ -14,7 +14,7 @@
     <div class="pure-g">
         <div class="pure-u-1">
             <div class="stats-summary mb-12">
-                <h2>Total {{ APP_ITEM_NAME_PLURAL }} Consumed: {{ total_consumed }}</h2>
+                <h2>Total {{ APP_ITEM_NAME_PLURAL|capfirst }} Consumed: {{ total_consumed }}</h2>
                 {% if avg_rating %}
                     <p>Average Rating: {{ avg_rating }}/3</p>
                 {% endif %}
@@ -50,7 +50,7 @@
                 </div>
 
                 <div class="pure-u-1 pure-u-md-1-2">
-                    <h3>By {{ APP_ITEM_NAME }} Type</h3>
+                    <h3>By {{ APP_ITEM_NAME|capfirst }} Type</h3>
                     {% if by_type %}
                         <canvas id="chartByType" height="250"></canvas>
                         <details class="mt-4">

--- a/wine_cellar/templates/core/reorder_reminders.html
+++ b/wine_cellar/templates/core/reorder_reminders.html
@@ -11,7 +11,7 @@
         <div class="pure-u-1">
             {% if needs_reorder %}
                 <div class="alert alert--warning mb-12">
-                    <h2>{{ APP_ITEM_NAME_PLURAL }} Needing Reorder</h2>
+                    <h2>{{ APP_ITEM_NAME_PLURAL|capfirst }} Needing Reorder</h2>
                     <table class="pure-table pure-table-horizontal pure-table-striped">
                         <thead>
                             <tr>

--- a/wine_cellar/templates/core/stats_dashboard.html
+++ b/wine_cellar/templates/core/stats_dashboard.html
@@ -20,7 +20,7 @@
             <div class="pure-g">
                 {# --- By Type --- #}
                 <div class="pure-u-1 pure-u-md-1-2">
-                    <h3>{{ APP_ITEM_NAME }} by Type</h3>
+                    <h3>{{ APP_ITEM_NAME|capfirst }} by Type</h3>
                     {% if by_type %}
                         <canvas id="chartByType" height="250"></canvas>
                         <details class="mt-4">


### PR DESCRIPTION
## Summary
- Fixes #146
- Adds `|capfirst` filter to `APP_ITEM_NAME` and `APP_ITEM_NAME_PLURAL` in headings where the variable appeared lowercase before capitalised words (e.g. "wine List" → "Wine List")
- Affected templates: `beverage_list.html`, `stats_dashboard.html`, `reorder_reminders.html`, `consumption_stats.html`