### PR TITLE
Fix drink record defaults

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -1,6 +1,7 @@
 """Tests for core shared views: QR code, random bottle, detail, list, delete, export."""
 
 import json
+from datetime import date
 from decimal import Decimal
 from http import HTTPStatus
 
@@ -515,6 +516,15 @@ class TestDrinkRecordCreateView:
         r = client.get(reverse("drink-record-add", kwargs={"pk": wine.pk}))
         assert r.status_code == HTTPStatus.OK
         assert r.context["beverage"].pk == wine.pk
+
+    def test_get_defaults_date_consumed_to_today(self, client, user, wine_factory):
+        wine = wine_factory(user=user)
+        client.force_login(user)
+        r = client.get(reverse("drink-record-add", kwargs={"pk": wine.pk}))
+        value = r.context["form"]["date_consumed"].value()
+        if hasattr(value, "isoformat"):
+            value = value.isoformat()
+        assert value == date.today().isoformat()
 
     def test_post_creates_record(self, client, user, wine_factory):
         from datetime import date

--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -1,12 +1,12 @@
 """Tests for core shared views: QR code, random bottle, detail, list, delete, export."""
 
 import json
-from datetime import date
 from decimal import Decimal
 from http import HTTPStatus
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 
 from wine_cellar.apps.wine.models import Wine, WineType
 
@@ -524,7 +524,7 @@ class TestDrinkRecordCreateView:
         value = r.context["form"]["date_consumed"].value()
         if hasattr(value, "isoformat"):
             value = value.isoformat()
-        assert value == date.today().isoformat()
+        assert value == timezone.localdate().isoformat()
 
     def test_post_creates_record(self, client, user, wine_factory):
         from datetime import date

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -259,6 +259,37 @@ def test_drink_record_form_exposes_fill_level_defaults_for_whisky(
 
 
 @pytest.mark.django_db
+def test_drink_record_form_bound_post_disables_auto_status_updates(
+    client, user, whisky_storage_item_factory
+):
+    from wine_cellar.apps.whisky.forms import POST_DRINK_STATUS_CONSUMED
+
+    household = user.user_settings.active_household
+    bottle = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky__user=user,
+        whisky__household=household,
+        fill_level=FillLevel.UNOPENED,
+    )
+
+    client.force_login(user)
+    response = client.post(
+        reverse("drink-record-add", kwargs={"pk": bottle.whisky.pk}),
+        {
+            "storage_item": bottle.pk,
+            "post_drink_status": POST_DRINK_STATUS_CONSUMED,
+            "date_consumed": "",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert "let isAutoManaged = false;" in response.content.decode()
+
+
+@pytest.mark.django_db
 def test_drink_record_with_selected_bottle_can_mark_consumed(
     client, user, whisky_storage_item_factory
 ):

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -212,6 +212,53 @@ def test_drink_record_form_invites_bottle_status_selection(
 
 
 @pytest.mark.django_db
+def test_drink_record_form_defaults_bottle_status_to_opened(
+    client, user, whisky_storage_item_factory
+):
+    household = user.user_settings.active_household
+    bottle = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky__user=user,
+        whisky__household=household,
+        fill_level=FillLevel.UNOPENED,
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("drink-record-add", kwargs={"pk": bottle.whisky.pk}))
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.context["form"]["post_drink_status"].value() == FillLevel.OPENED
+
+
+@pytest.mark.django_db
+def test_drink_record_form_exposes_fill_level_defaults_for_whisky(
+    client, user, whisky_storage_item_factory
+):
+    household = user.user_settings.active_household
+    bottle = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky__user=user,
+        whisky__household=household,
+        fill_level=FillLevel.DREG,
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("drink-record-add", kwargs={"pk": bottle.whisky.pk}))
+    html = response.content.decode()
+
+    assert response.status_code == HTTPStatus.OK
+    assert f'data-default-status="{FillLevel.OPENED}"' in html
+    assert f'data-dreg-status="{FillLevel.DREG}"' in html
+    assert f'data-fill-level="{FillLevel.DREG}"' in html
+
+
+@pytest.mark.django_db
 def test_drink_record_with_selected_bottle_can_mark_consumed(
     client, user, whisky_storage_item_factory
 ):

--- a/wine_cellar/apps/core/forms.py
+++ b/wine_cellar/apps/core/forms.py
@@ -2,6 +2,7 @@ import json
 
 from django import forms
 from django.conf import settings
+from django.utils import timezone
 
 from wine_cellar.apps.storage.models import Storage, StorageItem, get_app_type
 from wine_cellar.apps.user.views import get_active_household, get_user_settings
@@ -127,6 +128,7 @@ class BaseDrinkRecordForm(forms.Form):
         help_text="Select which bottle you consumed (optional).",
     )
     date_consumed = forms.DateField(
+        initial=timezone.localdate,
         widget=forms.DateInput(format="%Y-%m-%d", attrs={"type": "date"}),
         help_text="When did you drink this?",
     )

--- a/wine_cellar/apps/whisky/forms.py
+++ b/wine_cellar/apps/whisky/forms.py
@@ -798,14 +798,47 @@ class WhiskyStockAddForm(TomSelectMixin, forms.Form):
 POST_DRINK_STATUS_CONSUMED = "consumed"
 
 
+class WhiskyStorageItemSelect(forms.Select):
+    def create_option(
+        self,
+        name,
+        value,
+        label,
+        selected,
+        index,
+        subindex=None,
+        attrs=None,
+    ):
+        option = super().create_option(
+            name,
+            value,
+            label,
+            selected,
+            index,
+            subindex=subindex,
+            attrs=attrs,
+        )
+        storage_item = getattr(value, "instance", None)
+        if storage_item is not None:
+            option.setdefault("attrs", {})["data-fill-level"] = storage_item.fill_level
+        return option
+
+
 class WhiskyDrinkRecordForm(BaseDrinkRecordForm):
     storage_item_model = WhiskyStorageItem
     beverage_fk_name = "whisky"
     beverage_label = "whisky"
+    storage_item = forms.ModelChoiceField(
+        queryset=WhiskyStorageItem.objects.none(),
+        required=False,
+        label="Bottle",
+        help_text="Select which bottle you consumed (optional).",
+        widget=WhiskyStorageItemSelect,
+    )
 
     post_drink_status = forms.ChoiceField(
         required=False,
-        initial=POST_DRINK_STATUS_CONSUMED,
+        initial=FillLevel.OPENED,
         label="Bottle status after drink",
         choices=(
             (
@@ -818,6 +851,32 @@ class WhiskyDrinkRecordForm(BaseDrinkRecordForm):
         help_text="If you select a bottle, choose how that bottle "
         "should be updated.",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["post_drink_status"].initial = self.get_default_post_drink_status()
+        self.fields["post_drink_status"].widget.attrs.update(
+            {
+                "data-default-status": FillLevel.OPENED,
+                "data-dreg-status": FillLevel.DREG,
+            }
+        )
+
+    def get_default_post_drink_status(self):
+        bottle = self.get_initial_storage_item()
+        if bottle and bottle.fill_level == FillLevel.DREG:
+            return FillLevel.DREG
+        return FillLevel.OPENED
+
+    def get_initial_storage_item(self):
+        initial_storage_item = self.initial.get("storage_item")
+        if not initial_storage_item:
+            return None
+        if isinstance(initial_storage_item, WhiskyStorageItem):
+            return initial_storage_item
+        return (
+            self.fields["storage_item"].queryset.filter(pk=initial_storage_item).first()
+        )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/wine_cellar/templates/core/drink_record_create.html
+++ b/wine_cellar/templates/core/drink_record_create.html
@@ -1,5 +1,46 @@
 {% extends 'base.html' %}
 {% load static %}
+{% block extra_js %}
+    {{ block.super }}
+    {% if form.fields.post_drink_status %}
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                const bottleSelect = document.getElementById("id_storage_item");
+                const statusSelect = document.getElementById("id_post_drink_status");
+
+                if (!bottleSelect || !statusSelect) {
+                    return;
+                }
+
+                const defaultStatus = statusSelect.dataset.defaultStatus;
+                const dregStatus = statusSelect.dataset.dregStatus;
+
+                if (!defaultStatus || !dregStatus) {
+                    return;
+                }
+
+                let autoStatusValue = statusSelect.value;
+
+                const updateDefaultStatus = () => {
+                    const selectedOption = bottleSelect.options[bottleSelect.selectedIndex];
+                    const nextStatus =
+                        selectedOption && selectedOption.dataset.fillLevel === dregStatus
+                            ? dregStatus
+                            : defaultStatus;
+
+                    if (statusSelect.value === autoStatusValue || statusSelect.value === "") {
+                        statusSelect.value = nextStatus;
+                    }
+
+                    autoStatusValue = nextStatus;
+                };
+
+                updateDefaultStatus();
+                bottleSelect.addEventListener("change", updateDefaultStatus);
+            });
+        </script>
+    {% endif %}
+{% endblock extra_js %}
 {% block title %}
     Record Drink
 {% endblock title %}

--- a/wine_cellar/templates/core/drink_record_create.html
+++ b/wine_cellar/templates/core/drink_record_create.html
@@ -19,7 +19,7 @@
                     return;
                 }
 
-                let autoStatusValue = statusSelect.value;
+                let isAutoManaged = {% if form.is_bound %}false{% else %}true{% endif %};
 
                 const updateDefaultStatus = () => {
                     const selectedOption = bottleSelect.options[bottleSelect.selectedIndex];
@@ -28,15 +28,16 @@
                             ? dregStatus
                             : defaultStatus;
 
-                    if (statusSelect.value === autoStatusValue || statusSelect.value === "") {
+                    if (isAutoManaged) {
                         statusSelect.value = nextStatus;
                     }
-
-                    autoStatusValue = nextStatus;
                 };
 
                 updateDefaultStatus();
                 bottleSelect.addEventListener("change", updateDefaultStatus);
+                statusSelect.addEventListener("change", function () {
+                    isAutoManaged = false;
+                });
             });
         </script>
     {% endif %}


### PR DESCRIPTION
## Summary
- default drink dates to today in the shared drink record form
- default whisky bottle status to opened, or dreg when the selected bottle is already dreg
- add coverage for shared and whisky drink record defaults

## Testing
- make lint
- make pytest

Closes #169