### PR TITLE
fix bottle history links and consumed bottle visibility

### DIFF
--- a/tests/storage/test_views.py
+++ b/tests/storage/test_views.py
@@ -1,3 +1,4 @@
+from datetime import date
 from http import HTTPStatus
 
 import pytest
@@ -7,7 +8,7 @@ from pytest_django.asserts import (
     assertTemplateUsed,
 )
 
-from wine_cellar.apps.storage.models import Storage, StorageItem
+from wine_cellar.apps.storage.models import BottleMoveHistory, Storage, StorageItem
 
 
 @pytest.mark.django_db
@@ -376,3 +377,106 @@ def test_used_slot_is_free_after_delete(
     assert item.row == 1
     assert item.column == 1
     assert item.deleted is False
+
+
+@pytest.mark.django_db
+def test_bottle_history_shows_move_positions(
+    client, user, wine_factory, storage_item_factory
+):
+    wine = wine_factory(user=user)
+    storage = user.storage_set.first()
+    bottle = storage_item_factory(
+        wine=wine,
+        storage=storage,
+        user=user,
+        row=1,
+        column=1,
+    )
+    BottleMoveHistory.objects.create(
+        storage_item=bottle,
+        from_storage=storage,
+        from_row=1,
+        from_column=1,
+        to_storage=storage,
+        to_row=2,
+        to_column=3,
+        user=user,
+    )
+    bottle.row = 2
+    bottle.column = 3
+    bottle.save(update_fields=["row", "column"])
+
+    client.force_login(user)
+    r = client.get(reverse("bottle-history", kwargs={"pk": bottle.pk}))
+    content = r.content.decode()
+
+    assert r.status_code == HTTPStatus.OK
+    assert "Moved" in content
+    assert "Row 1, Cell 1" in content
+    assert "Row 2, Cell 3" in content
+
+
+@pytest.mark.django_db
+def test_bottle_history_shows_moves_between_storages(
+    client, user, wine_factory, storage_item_factory, storage_factory
+):
+    wine = wine_factory(user=user)
+    source_storage = user.storage_set.first()
+    target_storage = storage_factory(user=user, name="Archive Rack")
+    bottle = storage_item_factory(
+        wine=wine,
+        storage=source_storage,
+        user=user,
+        row=1,
+        column=1,
+    )
+    BottleMoveHistory.objects.create(
+        storage_item=bottle,
+        from_storage=source_storage,
+        from_row=1,
+        from_column=1,
+        to_storage=target_storage,
+        to_row=2,
+        to_column=3,
+        user=user,
+    )
+    bottle.storage = target_storage
+    bottle.row = 2
+    bottle.column = 3
+    bottle.save(update_fields=["storage", "row", "column"])
+
+    client.force_login(user)
+    r = client.get(reverse("bottle-history", kwargs={"pk": bottle.pk}))
+    content = r.content.decode()
+
+    assert r.status_code == HTTPStatus.OK
+    assert source_storage.name in content
+    assert target_storage.name in content
+    assert "Row 1, Cell 1" in content
+    assert "Row 2, Cell 3" in content
+
+
+@pytest.mark.django_db
+def test_consumed_bottle_history_links_back_to_consumed_bottles(
+    client, user, wine_factory, storage_item_factory
+):
+    wine = wine_factory(user=user)
+    storage = user.storage_set.first()
+    bottle = storage_item_factory(
+        wine=wine,
+        storage=storage,
+        user=user,
+        deleted=True,
+        finished_date=date(2025, 1, 5),
+    )
+
+    client.force_login(user)
+    r = client.get(reverse("bottle-history", kwargs={"pk": bottle.pk}))
+    content = r.content.decode()
+    expected_href = (
+        f'href="{reverse("wine-detail", kwargs={"pk": wine.pk})}'
+        "?show_consumed=1#consumed-bottles"
+    )
+
+    assert r.status_code == HTTPStatus.OK
+    assert expected_href in content

--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -229,6 +229,64 @@ class TestWineDetailView:
         recent = session.get("recent_views", [])
         assert any(r["pk"] == wine.pk for r in recent)
 
+    def test_consumed_bottles_are_hidden_by_default(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        wine = wine_factory(user=user)
+        storage = user.storage_set.first()
+        consumed_bottle = storage_item_factory(
+            wine=wine,
+            storage=storage,
+            user=user,
+            row=1,
+            column=2,
+            deleted=True,
+            finished_date=timezone.localdate(),
+        )
+        client.force_login(user)
+
+        r = client.get(reverse("wine-detail", kwargs={"pk": wine.pk}))
+        content = r.content.decode()
+
+        assert r.status_code == HTTPStatus.OK
+        assert r.context["consumed_bottle_count"] == 1
+        assert r.context["show_consumed_bottles"] is False
+        assert "Show consumed bottles (1)" in content
+        assert (
+            reverse("bottle-history", kwargs={"pk": consumed_bottle.pk}) not in content
+        )
+
+    def test_consumed_bottles_can_be_shown(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        wine = wine_factory(user=user)
+        storage = user.storage_set.first()
+        consumed_bottle = storage_item_factory(
+            wine=wine,
+            storage=storage,
+            user=user,
+            row=1,
+            column=2,
+            deleted=True,
+            finished_date=timezone.localdate(),
+        )
+        client.force_login(user)
+
+        r = client.get(
+            f"{reverse('wine-detail', kwargs={'pk': wine.pk})}?show_consumed=1"
+        )
+        content = r.content.decode()
+
+        assert r.status_code == HTTPStatus.OK
+        assert r.context["show_consumed_bottles"] is True
+        assert consumed_bottle in list(r.context["consumed_bottles"])
+        assert (
+            consumed_bottle.finished_date
+            == r.context["consumed_bottles"][0].finished_date
+        )
+        assert "Hide consumed bottles" in content
+        assert reverse("bottle-history", kwargs={"pk": consumed_bottle.pk}) in content
+
 
 # ---------------------------------------------------------------------------
 # Wine list view
@@ -821,6 +879,42 @@ class TestDrinkRecordListView:
         r = client.get(reverse("drink-history"))
         assert r.status_code == HTTPStatus.OK
         assert len(r.context["drink_records"]) == 1
+
+    def test_bottle_backed_records_link_to_bottle_history(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        from datetime import date
+
+        from wine_cellar.apps.wine.models import DrinkRecord
+
+        wine = wine_factory(user=user)
+        household = user.user_settings.active_household
+        storage = user.storage_set.first()
+        bottle = storage_item_factory(
+            wine=wine,
+            storage=storage,
+            user=user,
+            row=2,
+            column=3,
+            deleted=True,
+            finished_date=date(2025, 1, 5),
+        )
+        DrinkRecord.objects.create(
+            wine=wine,
+            user=user,
+            household=household,
+            date_consumed=date(2025, 1, 5),
+            storage_item=bottle,
+        )
+
+        client.force_login(user)
+        r = client.get(reverse("drink-history"))
+        content = r.content.decode()
+
+        assert r.status_code == HTTPStatus.OK
+        assert reverse("bottle-history", kwargs={"pk": bottle.pk}) in content
+        assert reverse("wine-detail", kwargs={"pk": wine.pk}) in content
+        assert "Row 2, Cell 3" in content
 
 
 # ---------------------------------------------------------------------------

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -81,7 +81,11 @@ class BaseDrinkRecordListView(RequireHouseholdMixin, TemplateView):
         household = get_active_household(self.request.user)
         context["drink_records"] = self.drink_record_model.objects.filter(
             household=household
-        ).select_related(self.beverage_fk_name)
+        ).select_related(
+            self.beverage_fk_name,
+            "storage_item",
+            "storage_item__storage",
+        )
         context["beverage_fk_name"] = self.beverage_fk_name
         context["beverage_icon"] = self.beverage_icon or "wine-glass"
         return context

--- a/wine_cellar/apps/storage/templates/bottle_history.html
+++ b/wine_cellar/apps/storage/templates/bottle_history.html
@@ -12,15 +12,9 @@
         <div class="pure-g">
             <div class="pure-u-1 pure-u-md-2-3">
                 <div style="margin-bottom: 1rem;">
-                    {% if CELLAR_APP_TYPE == "whisky" %}
-                        <a href="{% url 'whisky-detail' item.whisky.pk %}" class="pure-button button__neutral">
-                            <i class="fa-solid fa-arrow-left"></i> Back to {{ item.whisky.name }}
-                        </a>
-                    {% else %}
-                        <a href="{% url 'wine-detail' item.wine.pk %}" class="pure-button button__neutral">
-                            <i class="fa-solid fa-arrow-left"></i> Back to {{ item.wine.name }}
-                        </a>
-                    {% endif %}
+                    <a href="{{ beverage_detail_url }}" class="pure-button button__neutral">
+                        <i class="fa-solid fa-arrow-left"></i> Back to {{ beverage.name }}
+                    </a>
                 </div>
 
                 <h2>Bottle History</h2>

--- a/wine_cellar/apps/storage/utils.py
+++ b/wine_cellar/apps/storage/utils.py
@@ -1,0 +1,29 @@
+def format_bottle_location(storage, row, column):
+    parts = []
+    if storage:
+        parts.append(storage.name)
+
+    position_parts = []
+    if row is not None:
+        position_parts.append(f"Row {row}")
+    if column is not None:
+        position_parts.append(f"Cell {column}")
+
+    if position_parts:
+        parts.append(", ".join(position_parts))
+
+    return " - ".join(parts) if parts else "Unassigned"
+
+
+def format_move_detail(
+    from_storage,
+    from_row,
+    from_column,
+    to_storage,
+    to_row,
+    to_column,
+):
+    return (
+        f"{format_bottle_location(from_storage, from_row, from_column)}"
+        f" -> {format_bottle_location(to_storage, to_row, to_column)}"
+    )

--- a/wine_cellar/apps/storage/views.py
+++ b/wine_cellar/apps/storage/views.py
@@ -7,7 +7,7 @@ from django.db import models, transaction
 from django.forms import model_to_dict
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, DetailView, FormView, ListView
 from django.views.generic.list import MultipleObjectMixin
@@ -26,6 +26,7 @@ from wine_cellar.apps.storage.models import (
     StorageItem,
     get_app_type,
 )
+from wine_cellar.apps.storage.utils import format_bottle_location, format_move_detail
 from wine_cellar.apps.user.views import get_active_household
 from wine_cellar.apps.whisky.utils import classify_cask_type
 from wine_cellar.apps.wine.models import Wine
@@ -737,20 +738,25 @@ class BottleHistoryView(RequireHouseholdMixin, DetailView):
                 "type": "added",
                 "date": item.created.date(),
                 "label": "Added to cellar",
-                "detail": item.storage.name,
+                "detail": format_bottle_location(item.storage, item.row, item.column),
             }
         )
 
         moves = item.move_history.select_related("from_storage", "to_storage").all()
         for move in moves:
-            from_loc = move.from_storage.name if move.from_storage else "?"
-            to_loc = move.to_storage.name if move.to_storage else "?"
             events.append(
                 {
                     "type": "move",
                     "date": move.moved_at.date(),
                     "label": "Moved",
-                    "detail": f"{from_loc} → {to_loc}",
+                    "detail": format_move_detail(
+                        move.from_storage,
+                        move.from_row,
+                        move.from_column,
+                        move.to_storage,
+                        move.to_row,
+                        move.to_column,
+                    ),
                 }
             )
 
@@ -776,6 +782,11 @@ class BottleHistoryView(RequireHouseholdMixin, DetailView):
 
         context["events"] = sorted(events, key=lambda e: e["date"])
         context["beverage"] = item.wine
+        context["beverage_detail_url"] = reverse(
+            "wine-detail", kwargs={"pk": item.wine.pk}
+        )
+        if item.deleted:
+            context["beverage_detail_url"] += "?show_consumed=1#consumed-bottles"
         return context
 
 

--- a/wine_cellar/apps/whisky/views.py
+++ b/wine_cellar/apps/whisky/views.py
@@ -62,6 +62,7 @@ from wine_cellar.apps.household.mixins import (
     require_member,
 )
 from wine_cellar.apps.storage.models import Storage, get_app_type
+from wine_cellar.apps.storage.utils import format_bottle_location, format_move_detail
 from wine_cellar.apps.user.views import get_active_household
 from wine_cellar.apps.whisky.filters import WhiskyFilter, WhiskyStorageItemFilter
 from wine_cellar.apps.whisky.forms import (
@@ -1341,20 +1342,25 @@ class WhiskyBottleHistoryView(RequireHouseholdMixin, DetailView):
                 "type": "added",
                 "date": item.created.date(),
                 "label": "Added to collection",
-                "detail": item.storage.name,
+                "detail": format_bottle_location(item.storage, item.row, item.column),
             }
         )
 
         moves = item.move_history.select_related("from_storage", "to_storage").all()
         for move in moves:
-            from_loc = move.from_storage.name if move.from_storage else "?"
-            to_loc = move.to_storage.name if move.to_storage else "?"
             events.append(
                 {
                     "type": "move",
                     "date": move.moved_at.date(),
                     "label": "Moved",
-                    "detail": f"{from_loc} → {to_loc}",
+                    "detail": format_move_detail(
+                        move.from_storage,
+                        move.from_row,
+                        move.from_column,
+                        move.to_storage,
+                        move.to_row,
+                        move.to_column,
+                    ),
                 }
             )
 
@@ -1403,5 +1409,8 @@ class WhiskyBottleHistoryView(RequireHouseholdMixin, DetailView):
 
         context["events"] = sorted(events, key=lambda e: e["date"])
         context["beverage"] = item.whisky
+        context["beverage_detail_url"] = reverse(
+            "whisky-detail", kwargs={"pk": item.whisky.pk}
+        )
         context["is_whisky"] = True
         return context

--- a/wine_cellar/apps/wine/templates/wine_detail.html
+++ b/wine_cellar/apps/wine/templates/wine_detail.html
@@ -207,7 +207,7 @@
                     </div>
                 {% endif %}
             </div>
-            <div class="pure-u-1 pure-u-md-1 text-align-center">
+            <div class="pure-u-1 pure-u-md-1 text-align-center" id="wine-stock">
                 <h2 class="header__title">Stock</h2>
             </div>
             <div class="pure-u-1 pure-u-md-3-8 m-auto">
@@ -226,6 +226,21 @@
                            class="pure-button button__neutral"><i class="fa-solid fa-bell"></i> <span>Reorder Alert</span></a>
                     </div>
                 </div>
+                {% if consumed_bottle_count %}
+                    <div class="mb-12">
+                        {% if show_consumed_bottles %}
+                            <a href="{% url 'wine-detail' wine.pk %}#wine-stock"
+                               class="pure-button button__neutral button--sm">
+                                <i class="fa-solid fa-eye-slash"></i> Hide consumed bottles
+                            </a>
+                        {% else %}
+                            <a href="{% url 'wine-detail' wine.pk %}?show_consumed=1#consumed-bottles"
+                               class="pure-button button__neutral button--sm">
+                                <i class="fa-regular fa-clock-rotate-left"></i> Show consumed bottles ({{ consumed_bottle_count }})
+                            </a>
+                        {% endif %}
+                    </div>
+                {% endif %}
                 <div class="pure-u-1 pure-u-md-1">
                     {% if wine.get_stock %}
                         <div class="table-responsive">
@@ -280,6 +295,51 @@
                         </div>
                     {% endif %}
                 </div>
+                {% if show_consumed_bottles %}
+                    <div class="pure-u-1 pure-u-md-1 mt-12" id="consumed-bottles">
+                        <h3>Consumed Bottles</h3>
+                        <div class="table-responsive">
+                            <table class="pure-table pure-table-horizontal pure-table-striped wine-detail__stock-table">
+                                <thead>
+                                    <tr>
+                                        <th>Location</th>
+                                        <th>Row</th>
+                                        <th>Cell</th>
+                                        <th>Finished</th>
+                                        <th>Gift</th>
+                                        <th>Occasion</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                {% for item in consumed_bottles %}
+                                    <tr>
+                                        <td>{{ item.storage }}</td>
+                                        <td>{{ item.row|default_if_none:"" }}</td>
+                                        <td>{{ item.column|default_if_none:"" }}</td>
+                                        <td>{{ item.finished_date|default_if_none:"" }}</td>
+                                        <td>{% if item.is_gift %}<i class="fa-solid fa-gift" title="{{ item.gift_from|default:'' }}"></i>{% if item.gift_from %} {{ item.gift_from }}{% endif %}{% endif %}</td>
+                                        <td>{{ item.occasion|default_if_none:"" }}</td>
+                                        <td>
+                                            <a class="pure-button" href="{% url 'bottle-history' item.pk %}" title="History"><i class="fa-regular fa-clock-rotate-left"></i></a>
+                                        </td>
+                                    </tr>
+                                    {% if item.notes.all %}
+                                        <tr>
+                                            <td colspan="7" class="bottle-notes">
+                                                <strong>Notes:</strong>
+                                                <ul>
+                                                    {% for note in item.notes.all %}
+                                                        <li><em>{{ note.note_date }}</em>: {{ note.note }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </td>
+                                        </tr>
+                                    {% endif %}
+                                {% endfor %}
+                            </table>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
             {% if duplicates %}
             <div class="pure-u-1 pure-u-md-1 text-align-center">

--- a/wine_cellar/apps/wine/views/wine_crud.py
+++ b/wine_cellar/apps/wine/views/wine_crud.py
@@ -400,6 +400,23 @@ class WineDetailView(BaseDetailView):
         )
         if extraction_log:
             context["extraction_log"] = extraction_log
+
+        consumed_bottles = (
+            self.object.storageitem_set.filter(deleted=True)
+            .select_related("storage")
+            .prefetch_related("notes")
+            .order_by("-finished_date", "-created", "-pk")
+        )
+        context["consumed_bottle_count"] = consumed_bottles.count()
+        context["show_consumed_bottles"] = (
+            self.request.GET.get("show_consumed") == "1"
+            and context["consumed_bottle_count"] > 0
+        )
+        context["consumed_bottles"] = (
+            consumed_bottles
+            if context["show_consumed_bottles"]
+            else self.object.storageitem_set.none()
+        )
         return context
 
 

--- a/wine_cellar/templates/core/drink_record_list.html
+++ b/wine_cellar/templates/core/drink_record_list.html
@@ -28,7 +28,25 @@
                                 {% with bev=record|getbeverage:beverage_fk_name %}
                                 <tr>
                                     <td>{{ record.date_consumed }}</td>
-                                    <td><a href="{% bev_url 'detail' bev.pk %}">{{ bev.name }}</a></td>
+                                    <td>
+                                        {% if record.storage_item_id %}
+                                            <a href="{% url 'bottle-history' record.storage_item.pk %}">{{ bev.name }}</a>
+                                            <div class="text--gray text--small">
+                                                {% if record.storage_item.storage %}
+                                                    {{ record.storage_item.storage.name }}
+                                                {% endif %}
+                                                {% if record.storage_item.row is not None and record.storage_item.column is not None %}
+                                                    {% if record.storage_item.storage %} · {% endif %}
+                                                    Row {{ record.storage_item.row }}, Cell {{ record.storage_item.column }}
+                                                {% endif %}
+                                            </div>
+                                            <div class="text--small">
+                                                <a href="{% bev_url 'detail' bev.pk %}">View {{ APP_ITEM_NAME }}</a>
+                                            </div>
+                                        {% else %}
+                                            <a href="{% bev_url 'detail' bev.pk %}">{{ bev.name }}</a>
+                                        {% endif %}
+                                    </td>
                                     <td>{{ record.rating|default_if_none:"-" }}</td>
                                     <td>{{ record.shared_with|default_if_none:"-" }}</td>
                                     <td>{{ record.occasion|default_if_none:"-" }}</td>


### PR DESCRIPTION
## Summary
- make drink history link to the specific bottle when a record is tied to one
- show full move details in bottle history, including storage and row/cell, for same-storage and cross-storage moves
- add a wine detail toggle for consumed bottles and link consumed bottle history back into that section

## Testing
- make lint
- make pytest

Refs #171
Refs #172