### PR TITLE
fix iphone storage position selectors

### DIFF
--- a/tests/storage/test_storage_forms.py
+++ b/tests/storage/test_storage_forms.py
@@ -176,6 +176,13 @@ class TestStockAddForm:
         )
         assert form.is_valid(), form.errors
 
+    def test_row_and_column_use_native_select_widgets(self, user, storage_factory):
+        storage_factory(user=user, rows=5, columns=10)
+        form = StockAddForm(user=user)
+
+        assert form.fields["row"].widget.attrs["data-native-select"] == "true"
+        assert form.fields["column"].widget.attrs["data-native-select"] == "true"
+
     def test_missing_row_for_grid_storage(self, user, storage_factory):
         storage = storage_factory(user=user, rows=5, columns=10)
         form = StockAddForm(
@@ -307,6 +314,18 @@ class TestStockAddForm:
 
 @pytest.mark.django_db
 class TestStorageItemEditForm:
+    def test_row_and_column_use_native_select_widgets(
+        self, user, wine_factory, storage_factory, storage_item_factory
+    ):
+        storage = storage_factory(user=user, rows=5, columns=5)
+        wine = wine_factory(user=user)
+        item = storage_item_factory(storage=storage, wine=wine, row=2, column=3)
+
+        form = StorageItemEditForm(user=user, instance=item)
+
+        assert form.fields["row"].widget.attrs["data-native-select"] == "true"
+        assert form.fields["column"].widget.attrs["data-native-select"] == "true"
+
     def test_can_stay_in_same_position(
         self, user, wine_factory, storage_factory, storage_item_factory
     ):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,6 +84,11 @@ def test_native_select_widget_marks_select_to_skip_tomselect():
     assert widget.attrs["data-native-select"] == "true"
 
 
+def test_native_select_widget_enforces_native_marker():
+    widget = native_select_widget(**{"data-native-select": "false"})
+    assert widget.attrs["data-native-select"] == "true"
+
+
 # -- BottleNoteForm / ReorderReminderForm tests --
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,6 +12,7 @@ from wine_cellar.apps.core.forms import (
     BottleNoteForm,
     ReorderReminderForm,
     TomSelectMixin,
+    native_select_widget,
 )
 from wine_cellar.apps.core.templatetags.core_tags import _badge_impl, _rating_stars_impl
 from wine_cellar.apps.core.utils import base64_to_uploaded_file
@@ -76,6 +77,11 @@ def test_tomselect_mixin_max_options_unlimited():
     form.set_tom_config("colour", max_options=-1)
     config = json.loads(form.fields["colour"].widget.attrs["data-tom_config"])
     assert config["maxOptions"] is None
+
+
+def test_native_select_widget_marks_select_to_skip_tomselect():
+    widget = native_select_widget()
+    assert widget.attrs["data-native-select"] == "true"
 
 
 # -- BottleNoteForm / ReorderReminderForm tests --

--- a/tests/test_wine_form_submission.py
+++ b/tests/test_wine_form_submission.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 
 from wine_cellar.apps.storage.models import StorageItem
+from wine_cellar.apps.wine.forms import WineForm
 from wine_cellar.apps.wine.models import Wine, WineBarcode
 
 
@@ -15,6 +16,27 @@ def _minimal_wine_data(**overrides):
     }
     data.update(overrides)
     return data
+
+
+@pytest.mark.django_db
+def test_wine_form_storage_fields_use_native_select_widgets(user):
+    form = WineForm(user=user)
+
+    assert form.fields["row"].widget.attrs["data-native-select"] == "true"
+    assert form.fields["column"].widget.attrs["data-native-select"] == "true"
+
+
+@pytest.mark.django_db
+def test_wine_edit_view_storage_fields_use_native_select_widgets(
+    client, user, wine_factory
+):
+    wine = wine_factory(user=user)
+    client.force_login(user)
+    response = client.get(reverse("wine-edit", kwargs={"pk": wine.pk}))
+    form = response.context["form"]
+
+    assert form.fields["row"].widget.attrs["data-native-select"] == "true"
+    assert form.fields["column"].widget.attrs["data-native-select"] == "true"
 
 
 @pytest.mark.django_db

--- a/tests/whisky/test_forms.py
+++ b/tests/whisky/test_forms.py
@@ -1,0 +1,33 @@
+import pytest
+from django.urls import reverse
+
+from wine_cellar.apps.whisky.forms import WhiskyForm, WhiskyStockAddForm
+
+
+@pytest.mark.django_db
+def test_whisky_form_storage_fields_use_native_select_widgets(user):
+    form = WhiskyForm(user=user)
+
+    assert form.fields["row"].widget.attrs["data-native-select"] == "true"
+    assert form.fields["column"].widget.attrs["data-native-select"] == "true"
+
+
+@pytest.mark.django_db
+def test_whisky_edit_view_storage_fields_use_native_select_widgets(
+    client, user, whisky_factory
+):
+    whisky = whisky_factory(user=user)
+    client.force_login(user)
+    response = client.get(reverse("whisky-edit", kwargs={"pk": whisky.pk}))
+    form = response.context["form"]
+
+    assert form.fields["row"].widget.attrs["data-native-select"] == "true"
+    assert form.fields["column"].widget.attrs["data-native-select"] == "true"
+
+
+@pytest.mark.django_db
+def test_whisky_stock_add_form_storage_fields_use_native_select_widgets(user):
+    form = WhiskyStockAddForm(user=user)
+
+    assert form.fields["row"].widget.attrs["data-native-select"] == "true"
+    assert form.fields["column"].widget.attrs["data-native-select"] == "true"

--- a/wine_cellar/apps/core/forms.py
+++ b/wine_cellar/apps/core/forms.py
@@ -42,6 +42,10 @@ class TomSelectMixin:
         )
 
 
+def native_select_widget(**attrs):
+    return forms.Select(attrs={"data-native-select": "true", **attrs})
+
+
 class BeverageBaseFormMixin:
     """Shared __init__ logic for WineBaseForm and WhiskyBaseForm.
 

--- a/wine_cellar/apps/core/forms.py
+++ b/wine_cellar/apps/core/forms.py
@@ -43,7 +43,9 @@ class TomSelectMixin:
 
 
 def native_select_widget(**attrs):
-    return forms.Select(attrs={"data-native-select": "true", **attrs})
+    select_attrs = {**attrs}
+    select_attrs["data-native-select"] = "true"
+    return forms.Select(attrs=select_attrs)
 
 
 class BeverageBaseFormMixin:

--- a/wine_cellar/apps/storage/forms.py
+++ b/wine_cellar/apps/storage/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 
+from wine_cellar.apps.core.forms import native_select_widget
 from wine_cellar.apps.storage.models import Storage, get_app_type
 from wine_cellar.apps.user.views import get_active_household, get_user_settings
 
@@ -137,13 +138,13 @@ class StockAddForm(forms.Form):
         required=False,
         min_value=0,
         help_text="Enter the number of rows in the storage.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     column = forms.IntegerField(
         required=False,
         min_value=0,
         help_text="Enter the number of columns in the storage.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     price = forms.DecimalField(
         required=False,
@@ -257,13 +258,13 @@ class StorageItemEditForm(forms.Form):
         required=False,
         min_value=0,
         help_text="Enter the row number.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     column = forms.IntegerField(
         required=False,
         min_value=0,
         help_text="Enter the column number.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     price = forms.DecimalField(
         required=False,

--- a/wine_cellar/apps/whisky/forms.py
+++ b/wine_cellar/apps/whisky/forms.py
@@ -10,6 +10,7 @@ from wine_cellar.apps.core.forms import (
     BaseDrinkRecordForm,
     BeverageBaseFormMixin,
     TomSelectMixin,
+    native_select_widget,
 )
 from wine_cellar.apps.storage.models import Storage, get_app_type
 from wine_cellar.apps.user.views import get_active_household
@@ -341,14 +342,14 @@ class WhiskyBaseForm(
         min_value=1,
         label="Row",
         help_text="Select the row in the storage.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     column = forms.IntegerField(
         required=False,
         min_value=1,
         label="Column",
         help_text="Select the column in the storage.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     bottle_price = forms.DecimalField(
         required=False,
@@ -765,13 +766,13 @@ class WhiskyStockAddForm(TomSelectMixin, forms.Form):
         required=False,
         min_value=1,
         label="Row",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     column = forms.IntegerField(
         required=False,
         min_value=1,
         label="Column",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     price = forms.DecimalField(
         required=False,

--- a/wine_cellar/apps/wine/forms.py
+++ b/wine_cellar/apps/wine/forms.py
@@ -12,6 +12,7 @@ from wine_cellar.apps.core.forms import (
     BaseDrinkRecordForm,
     BeverageBaseFormMixin,
     TomSelectMixin,
+    native_select_widget,
 )
 from wine_cellar.apps.storage.models import Storage, StorageItem
 from wine_cellar.apps.wine.fields import OpenMultipleChoiceField
@@ -341,14 +342,14 @@ class WineBaseForm(
         min_value=1,
         label="Row",
         help_text="Select the row in the storage.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     column = forms.IntegerField(
         required=False,
         min_value=1,
         label="Column",
         help_text="Select the column in the storage.",
-        widget=forms.Select(),
+        widget=native_select_widget(),
     )
     bottle_price = forms.DecimalField(
         required=False,

--- a/wine_cellar/assets/js/init_tom_select.ts
+++ b/wine_cellar/assets/js/init_tom_select.ts
@@ -7,7 +7,7 @@ import { RecursivePartial, TomCreateCallback} from 'tom-select/dist/esm/types/co
 const tsInstances: Record<string, TomSelect> = {}
 
 function initTomSelect (): void {
-  document.querySelectorAll('select').forEach((el) => {
+  document.querySelectorAll('select:not([data-native-select="true"])').forEach((el) => {
     const rawConfig : string | undefined = el.dataset.tom_config
     const clear : boolean = Boolean(JSON.parse(el.dataset.clear ?? "false"))
     const clearOpts : boolean = Boolean(JSON.parse(el.dataset.clearOpts ?? "false"))


### PR DESCRIPTION
## Summary
- use native selects for storage row/column fields instead of TomSelect
- keep the TomSelect bootstrap off fields explicitly marked for native iPhone picker behavior
- cover the shared storage forms with tests so wine and whisky edit flows stay fixed

## Testing
- make lint
- make pytest