### PR TITLE
add next ghcr deploy and review fixes

### DIFF
--- a/.github/workflows/rpi-docker.yml
+++ b/.github/workflows/rpi-docker.yml
@@ -2,7 +2,7 @@ name: Build and Push RPi4 Docker Image
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
     paths:
       - 'wine_cellar/**'
       - 'fixtures/**'
@@ -25,7 +25,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.head_commit.message, 'bump:')
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/next' || startsWith(github.event.head_commit.message, 'bump:')
 
     steps:
       - uses: actions/checkout@v6
@@ -52,7 +52,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=sha,prefix=,format=short
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
 
       - name: Build and push ARM64 image
         uses: docker/build-push-action@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,7 @@ For production deployment:
 - **Commit style**: Short, lowercase messages describing the change
 - **Stage-commit-push**: User often requests these as a single action
 - **Lint before commit**: Always run `make lint` and fix issues before committing
+- **No local leftovers**: After completing requested work, do not leave local-only changes in the worktree. Commit and push requested changes, or explicitly clean up/revert anything that should not remain.
 - **No heredocs in git commits**: Never use `cat <<'EOF'` or heredoc syntax for commit messages. Just pass the message directly with `git commit -m "message"`. For multi-line messages use multiple `-m` flags (e.g. `git commit -m "subject" -m "body"`).
 - **No co-author tags**: Never add `Co-Authored-By` lines to commit messages. This is the user's code.
 - **Save conversations**: Always save a copy of the conversation to `.claude/logs/` for later review

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ ARGUMENTS=$(filter-out $(firstword $(MAKECMDGOALS)), $(MAKECMDGOALS))
 DEV_COMPOSE = docker compose -f docker-compose.yml
 PROD_COMPOSE = docker compose -f docker-compose.prod.yml
 GHCR_IMAGE ?= ghcr.io/jonhall145/wine-cellar-personal:latest
+GHCR_NEXT_IMAGE ?= ghcr.io/jonhall145/wine-cellar-personal:next
+PROD_IMAGE ?= wine-cellar:prod
 NODE_RUN = docker run --rm -v "$$(pwd)":/app -v /app/node_modules -w /app node:20-slim
 
 .PHONY: all
@@ -59,7 +61,8 @@ help:
 	@echo "    make deploy               Rebuild and redeploy full production stack"
 	@echo "    make wine-deploy          Build/deploy wine app and restart nginx"
 	@echo "    make whisky-deploy        Build/deploy whisky app and restart nginx"
-	@echo "    make ghcr-deploy          Pull/deploy from GitHub Container Registry image"
+	@echo "    make ghcr-deploy          Pull/deploy the GitHub Container Registry latest image"
+	@echo "    make ghcr-deploy-next     Pull/deploy the GitHub Container Registry next image"
 	@echo ""
 	@echo "  Production"
 	@echo "    make wine-prod-start      Start wine container"
@@ -116,7 +119,14 @@ deploy:
 .PHONY: ghcr-deploy
 ghcr-deploy:
 	docker pull $(GHCR_IMAGE)
-	docker tag $(GHCR_IMAGE) wine-cellar:prod
+	docker tag $(GHCR_IMAGE) $(PROD_IMAGE)
+	chown -R 100:101 /mnt/usb/media/wine/ /mnt/usb/media/whisky/ 2>/dev/null || true
+	$(PROD_COMPOSE) up -d --no-build --force-recreate --remove-orphans
+
+.PHONY: ghcr-deploy-next
+ghcr-deploy-next:
+	docker pull $(GHCR_NEXT_IMAGE)
+	docker tag $(GHCR_NEXT_IMAGE) $(PROD_IMAGE)
 	chown -R 100:101 /mnt/usb/media/wine/ /mnt/usb/media/whisky/ 2>/dev/null || true
 	$(PROD_COMPOSE) up -d --no-build --force-recreate --remove-orphans
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Run `make help` for the full list. Key targets:
 | `make lint` | Run all linters (Black, isort, flake8, ESLint) |
 | `make lint-quick` | Quick lint (staged JS + migrations) |
 | **Deployment** | |
-| `make ghcr-deploy` | Pull and deploy from GitHub Container Registry |
+| `make ghcr-deploy` | Pull and deploy the GHCR `latest` image |
+| `make ghcr-deploy-next` | Pull and deploy the GHCR `next` image |
 | `make deploy` | Rebuild and redeploy full production stack |
 | **Versioning** | |
 | `make version` | Print current version |
@@ -206,8 +207,11 @@ Tests use pytest with pytest-django. End-to-end tests use Playwright and auto-sk
 Production deployment uses Docker with images published to GitHub Container Registry.
 
 ```bash
-# Pull latest image and redeploy all containers
+# Pull latest release image and redeploy all containers
 make ghcr-deploy
+
+# Pull the next-branch image and redeploy all containers
+make ghcr-deploy-next
 ```
 
 The production stack includes:

--- a/tests/storage/test_storage_api.py
+++ b/tests/storage/test_storage_api.py
@@ -323,15 +323,27 @@ class TestStorageItemHistory:
             removal_reason=StorageItem.RemovalReason.REMOVED,
             finished_date=timezone.localdate() - timedelta(days=5),
         )
+        undated_removed = storage_item_factory(
+            wine=wine_factory(user=user, name="Undated Removed"),
+            storage=storage,
+            user=user,
+            deleted=True,
+            removal_reason=StorageItem.RemovalReason.REMOVED,
+        )
+        StorageItem.objects.filter(pk=undated_removed.pk).update(
+            created=timezone.now() - timedelta(days=20)
+        )
+        undated_removed.refresh_from_db()
 
         client.force_login(user)
         r = client.get(reverse("stock-history"))
 
         assert r.status_code == 200
-        assert list(r.context["storage_items"])[:3] == [
+        assert list(r.context["storage_items"])[:4] == [
             newest_given,
             middle_removed,
             older_consumed,
+            undated_removed,
         ]
 
 

--- a/tests/storage/test_storage_api.py
+++ b/tests/storage/test_storage_api.py
@@ -1,7 +1,9 @@
 import json
+from datetime import timedelta
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 
 from wine_cellar.apps.storage.models import BottleMoveHistory, Storage, StorageItem
 
@@ -292,6 +294,45 @@ class TestStorageItemHistory:
         client.force_login(user)
         r = client.get(reverse("stock-history"))
         assert r.status_code == 200
+
+    def test_orders_removed_bottles_by_removal_date(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        storage = user.storage_set.first()
+        older_consumed = storage_item_factory(
+            wine=wine_factory(user=user, name="Older Consumed"),
+            storage=storage,
+            user=user,
+            deleted=True,
+            finished_date=timezone.localdate() - timedelta(days=10),
+        )
+        newest_given = storage_item_factory(
+            wine=wine_factory(user=user, name="Newest Given"),
+            storage=storage,
+            user=user,
+            deleted=True,
+            removal_reason=StorageItem.RemovalReason.GIVEN,
+            recipient="Alex",
+            given_date=timezone.localdate() - timedelta(days=1),
+        )
+        middle_removed = storage_item_factory(
+            wine=wine_factory(user=user, name="Middle Removed"),
+            storage=storage,
+            user=user,
+            deleted=True,
+            removal_reason=StorageItem.RemovalReason.REMOVED,
+            finished_date=timezone.localdate() - timedelta(days=5),
+        )
+
+        client.force_login(user)
+        r = client.get(reverse("stock-history"))
+
+        assert r.status_code == 200
+        assert list(r.context["storage_items"])[:3] == [
+            newest_given,
+            middle_removed,
+            older_consumed,
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -318,6 +318,31 @@ class TestWineDetailView:
         assert "Given Bottles" in content
         assert "Dana" in content
 
+    def test_given_bottles_toggle_links_to_gifted_section(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        wine = wine_factory(user=user)
+        storage = user.storage_set.first()
+        storage_item_factory(
+            wine=wine,
+            storage=storage,
+            user=user,
+            deleted=True,
+            removal_reason=StorageItem.RemovalReason.GIVEN,
+            recipient="Dana",
+            given_date=timezone.localdate(),
+        )
+        client.force_login(user)
+
+        r = client.get(reverse("wine-detail", kwargs={"pk": wine.pk}))
+        content = r.content.decode()
+
+        assert r.status_code == HTTPStatus.OK
+        assert (
+            f'href="{reverse("wine-detail", kwargs={"pk": wine.pk})}'
+            "?show_consumed=1#gifted-bottles"
+        ) in content
+
 
 # ---------------------------------------------------------------------------
 # Wine list view

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+from django.utils import timezone
 from pytest_django.asserts import assertRedirects, assertTemplateUsed
 
 from wine_cellar.apps.whisky.models import (
@@ -225,8 +226,8 @@ def test_whisky_list_defaults_to_in_stock_and_oldest_first(
     oldest = whisky_factory(user=user, name="Oldest")
     newest = whisky_factory(user=user, name="Newest")
     out_of_stock = whisky_factory(user=user, name="Out of Stock")
-    old_created = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=30)
-    new_created = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
+    old_created = timezone.now() - datetime.timedelta(days=30)
+    new_created = timezone.now() - datetime.timedelta(days=1)
     Whisky.objects.filter(pk=oldest.pk).update(created=old_created)
     Whisky.objects.filter(pk=newest.pk).update(created=new_created)
 
@@ -318,6 +319,53 @@ def test_given_whisky_bottle_history_shows_recipient_and_occasion(
     assert "Given away" in content
     assert "Jamie" in content
     assert "Thank you" in content
+
+
+@pytest.mark.django_db
+def test_whisky_stock_history_orders_by_removal_date(
+    client, user, whisky_factory, whisky_storage_item_factory
+):
+    household = user.user_settings.active_household
+    older_consumed = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky=whisky_factory(user=user, name="Older Consumed"),
+        deleted=True,
+        finished_date=timezone.localdate() - datetime.timedelta(days=10),
+    )
+    newest_given = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky=whisky_factory(user=user, name="Newest Given"),
+        deleted=True,
+        removal_reason=WhiskyStorageItem.RemovalReason.GIVEN,
+        recipient="Jamie",
+        given_date=timezone.localdate() - datetime.timedelta(days=1),
+    )
+    middle_removed = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky=whisky_factory(user=user, name="Middle Removed"),
+        deleted=True,
+        removal_reason=WhiskyStorageItem.RemovalReason.REMOVED,
+        finished_date=timezone.localdate() - datetime.timedelta(days=5),
+    )
+
+    client.force_login(user)
+    response = client.get(reverse("stock-history"))
+
+    assert response.status_code == HTTPStatus.OK
+    assert list(response.context["storage_items"])[:3] == [
+        newest_given,
+        middle_removed,
+        older_consumed,
+    ]
 
 
 @pytest.mark.django_db

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -356,15 +356,29 @@ def test_whisky_stock_history_orders_by_removal_date(
         removal_reason=WhiskyStorageItem.RemovalReason.REMOVED,
         finished_date=timezone.localdate() - datetime.timedelta(days=5),
     )
+    undated_removed = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky=whisky_factory(user=user, name="Undated Removed"),
+        deleted=True,
+        removal_reason=WhiskyStorageItem.RemovalReason.REMOVED,
+    )
+    WhiskyStorageItem.objects.filter(pk=undated_removed.pk).update(
+        created=timezone.now() - datetime.timedelta(days=20)
+    )
+    undated_removed.refresh_from_db()
 
     client.force_login(user)
     response = client.get(reverse("stock-history"))
 
     assert response.status_code == HTTPStatus.OK
-    assert list(response.context["storage_items"])[:3] == [
+    assert list(response.context["storage_items"])[:4] == [
         newest_given,
         middle_removed,
         older_consumed,
+        undated_removed,
     ]
 
 

--- a/wine_cellar/apps/storage/utils.py
+++ b/wine_cellar/apps/storage/utils.py
@@ -1,3 +1,6 @@
+from django.db.models.functions import Coalesce
+
+
 def format_bottle_location(storage, row, column):
     parts = []
     if storage:
@@ -36,3 +39,7 @@ def format_given_detail(recipient, occasion=""):
     if occasion:
         parts.append(f"Occasion: {occasion}")
     return "\n".join(parts)
+
+
+def with_removal_sort_date(queryset):
+    return queryset.annotate(removal_sort_date=Coalesce("given_date", "finished_date"))

--- a/wine_cellar/apps/storage/utils.py
+++ b/wine_cellar/apps/storage/utils.py
@@ -1,4 +1,4 @@
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, TruncDate
 
 
 def format_bottle_location(storage, row, column):
@@ -42,4 +42,10 @@ def format_given_detail(recipient, occasion=""):
 
 
 def with_removal_sort_date(queryset):
-    return queryset.annotate(removal_sort_date=Coalesce("given_date", "finished_date"))
+    return queryset.annotate(
+        removal_sort_date=Coalesce(
+            "given_date",
+            "finished_date",
+            TruncDate("created"),
+        )
+    )

--- a/wine_cellar/apps/storage/views.py
+++ b/wine_cellar/apps/storage/views.py
@@ -32,6 +32,7 @@ from wine_cellar.apps.storage.utils import (
     format_bottle_location,
     format_given_detail,
     format_move_detail,
+    with_removal_sort_date,
 )
 from wine_cellar.apps.user.views import get_active_household
 from wine_cellar.apps.whisky.utils import classify_cask_type
@@ -365,12 +366,9 @@ class StorageItemHistoryView(ListView):
     paginate_by = 10
 
     def get_queryset(self):
-        qs = (
-            super()
-            .get_queryset()
-            .select_related("wine", "storage")
-            .order_by("-given_date", "-finished_date", "-created")
-        )
+        qs = with_removal_sort_date(
+            super().get_queryset().select_related("wine", "storage")
+        ).order_by("-removal_sort_date", "-created", "-pk")
         household = get_active_household(self.request.user)
         return qs.filter(household=household, deleted=True)
 

--- a/wine_cellar/apps/whisky/views.py
+++ b/wine_cellar/apps/whisky/views.py
@@ -68,6 +68,7 @@ from wine_cellar.apps.storage.utils import (
     format_bottle_location,
     format_given_detail,
     format_move_detail,
+    with_removal_sort_date,
 )
 from wine_cellar.apps.user.views import get_active_household
 from wine_cellar.apps.whisky.filters import WhiskyFilter, WhiskyStorageItemFilter
@@ -1313,11 +1314,11 @@ class StorageItemHistoryView(RequireHouseholdMixin, ListView):
 
     def get_queryset(self):
         household = get_active_household(self.request.user)
-        return (
-            WhiskyStorageItem.objects.filter(household=household, deleted=True)
-            .select_related("whisky", "storage")
-            .order_by("-given_date", "-finished_date", "-created")
-        )
+        return with_removal_sort_date(
+            WhiskyStorageItem.objects.filter(
+                household=household, deleted=True
+            ).select_related("whisky", "storage")
+        ).order_by("-removal_sort_date", "-created", "-pk")
 
 
 class WhiskyMergeConfirmView(BaseMergeConfirmView):

--- a/wine_cellar/apps/wine/templates/wine_detail.html
+++ b/wine_cellar/apps/wine/templates/wine_detail.html
@@ -241,8 +241,8 @@
                                 {% endif %}
                             </a>
                         {% else %}
-                            <a href="{% url 'wine-detail' wine.pk %}?show_consumed=1#consumed-bottles"
-                               class="pure-button button__neutral button--sm">
+                            <a href="{% url 'wine-detail' wine.pk %}?show_consumed=1#{% if gifted_bottle_count and not consumed_bottle_count %}gifted-bottles{% else %}consumed-bottles{% endif %}"
+                                class="pure-button button__neutral button--sm">
                                 <i class="fa-regular fa-clock-rotate-left"></i>
                                 {% if gifted_bottle_count and not consumed_bottle_count %}
                                     Show given bottles ({{ gifted_bottle_count }})

--- a/wine_cellar/apps/wine/views/wine_crud.py
+++ b/wine_cellar/apps/wine/views/wine_crud.py
@@ -21,6 +21,7 @@ from wine_cellar.apps.core.views import (
 )
 from wine_cellar.apps.household.mixins import require_member
 from wine_cellar.apps.storage.models import StorageItem
+from wine_cellar.apps.storage.utils import with_removal_sort_date
 from wine_cellar.apps.user.views import get_active_household
 from wine_cellar.apps.wine.filters import WineFilter
 from wine_cellar.apps.wine.forms import WineBaseForm, WineEditForm, WineForm
@@ -401,12 +402,11 @@ class WineDetailView(BaseDetailView):
         if extraction_log:
             context["extraction_log"] = extraction_log
 
-        removed_bottles = (
+        removed_bottles = with_removal_sort_date(
             self.object.storageitem_set.filter(deleted=True)
             .select_related("storage")
             .prefetch_related("notes")
-            .order_by("-given_date", "-finished_date", "-created", "-pk")
-        )
+        ).order_by("-removal_sort_date", "-created", "-pk")
         consumed_bottles = removed_bottles.exclude(
             removal_reason=StorageItem.RemovalReason.GIVEN
         )


### PR DESCRIPTION
## Summary
- publish a separate GHCR `next` image and add `make ghcr-deploy-next`
- fix removed-bottle ordering and gifted-bottle anchor behavior from PR review feedback
- document the workflow rule to avoid leaving local-only changes in the worktree

## Validation
- make lint
- focused wine/whisky regression tests in the dev container