### PR TITLE
refactor: deduplicate beverage image and extraction log handling

### DIFF
--- a/tests/test_wine_form_submission.py
+++ b/tests/test_wine_form_submission.py
@@ -1,9 +1,18 @@
+import io
+
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+from PIL import Image
 
 from wine_cellar.apps.storage.models import StorageItem
 from wine_cellar.apps.wine.forms import WineForm
-from wine_cellar.apps.wine.models import Wine, WineBarcode
+from wine_cellar.apps.wine.models import (
+    VisionExtractionLog,
+    Wine,
+    WineBarcode,
+    WineImage,
+)
 
 
 def _minimal_wine_data(**overrides):
@@ -16,6 +25,13 @@ def _minimal_wine_data(**overrides):
     }
     data.update(overrides)
     return data
+
+
+def _test_image_upload(name="front.jpg"):
+    buffer = io.BytesIO()
+    Image.new("RGB", (20, 20), color="red").save(buffer, format="JPEG")
+    buffer.seek(0)
+    return SimpleUploadedFile(name, buffer.getvalue(), content_type="image/jpeg")
 
 
 @pytest.mark.django_db
@@ -96,6 +112,38 @@ class TestWineCreateView:
         bc = WineBarcode.objects.get(wine=wine)
         assert bc.barcode == "1234567890123"
         assert bc.user == user
+
+    def test_create_links_extraction_log_and_saves_label_image(
+        self, client, user, clear_image_folder
+    ):
+        client.force_login(user)
+        household = user.user_settings.active_household
+        log = VisionExtractionLog.objects.create(
+            user=user,
+            household=household,
+            image_count=1,
+            raw_response="{}",
+            extracted_data={"name": "Test Wine"},
+            confidence="high",
+            extracted_fields=["name"],
+        )
+        session = client.session
+        session["extraction_result"] = {"extracted_data": {"name": "Test Wine"}}
+        session.save()
+        image = _test_image_upload()
+
+        r = client.post(
+            reverse("wine-add"),
+            _minimal_wine_data(image_front_label=image),
+            follow=True,
+        )
+
+        assert r.status_code == 200
+        wine = Wine.objects.get(name="Test Wine")
+        log.refresh_from_db()
+        assert log.wine == wine
+        assert log.was_successful is True
+        assert WineImage.objects.filter(wine=wine, image_type="LF").count() == 1
 
     def test_missing_name_returns_form_error(self, client, user):
         """POST without required `name` field re-renders the form with errors."""
@@ -193,3 +241,24 @@ class TestWineUpdateView:
         r = client.post(reverse("wine-edit", kwargs={"pk": wine.pk}), data)
         assert r.status_code == 302
         assert r.url == reverse("wine-detail", kwargs={"pk": wine.pk})
+
+    def test_update_replaces_front_label_image(
+        self, client, user, wine_factory, wine_image_factory, clear_image_folder
+    ):
+        wine = wine_factory(user=user)
+        existing_image = wine_image_factory(user=user, wine=wine, image_type="LF")
+        client.force_login(user)
+        replacement_image = _test_image_upload("replacement.jpg")
+        data = _minimal_wine_data(
+            name=wine.name,
+            wine_type=wine.wine_type,
+            country=wine.country,
+            image_front_label=replacement_image,
+        )
+
+        r = client.post(reverse("wine-edit", kwargs={"pk": wine.pk}), data, follow=True)
+
+        assert r.status_code == 200
+        front_images = WineImage.objects.filter(wine=wine, image_type="LF")
+        assert front_images.count() == 1
+        assert front_images.get().pk != existing_image.pk

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -15,6 +15,7 @@ from wine_cellar.apps.whisky.models import (
     Whisky,
     WhiskyDrinkRecord,
     WhiskyStorageItem,
+    WhiskyVisionExtractionLog,
 )
 
 
@@ -593,6 +594,47 @@ def test_whisky_detail_loads(client, user, whisky_factory):
     assert r.status_code == HTTPStatus.OK
     assertTemplateUsed(response=r, template_name="whisky/whisky_detail.html")
     assert r.context["object"] == whisky
+
+
+@pytest.mark.django_db
+def test_whisky_detail_uses_latest_successful_extraction_log(
+    client, user, whisky_factory
+):
+    whisky = whisky_factory(user=user, name="Ardbeg 10")
+    household = whisky.household
+    WhiskyVisionExtractionLog.objects.create(
+        user=user,
+        household=household,
+        whisky=whisky,
+        extracted_data={"name": whisky.name},
+        confidence="medium",
+        extracted_fields=["name"],
+        was_successful=True,
+    )
+    latest_success = WhiskyVisionExtractionLog.objects.create(
+        user=user,
+        household=household,
+        whisky=whisky,
+        extracted_data={"name": whisky.name},
+        confidence="high",
+        extracted_fields=["name"],
+        was_successful=True,
+    )
+    WhiskyVisionExtractionLog.objects.create(
+        user=user,
+        household=household,
+        whisky=whisky,
+        extracted_data={"name": whisky.name},
+        confidence="low",
+        extracted_fields=["name"],
+        was_successful=False,
+    )
+
+    client.force_login(user)
+    r = client.get(reverse("whisky-detail", kwargs={"pk": whisky.pk}))
+
+    assert r.status_code == HTTPStatus.OK
+    assert r.context["extraction_log"].pk == latest_success.pk
 
 
 @pytest.mark.django_db

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+import io
 import json
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
@@ -7,6 +8,7 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils import timezone
+from PIL import Image
 from pytest_django.asserts import assertRedirects, assertTemplateUsed
 
 from wine_cellar.apps.whisky.models import (
@@ -14,9 +16,17 @@ from wine_cellar.apps.whisky.models import (
     FillLevel,
     Whisky,
     WhiskyDrinkRecord,
+    WhiskyImage,
     WhiskyStorageItem,
     WhiskyVisionExtractionLog,
 )
+
+
+def _test_image_upload(name="front.jpg"):
+    buffer = io.BytesIO()
+    Image.new("RGB", (20, 20), color="red").save(buffer, format="JPEG")
+    buffer.seek(0)
+    return SimpleUploadedFile(name, buffer.getvalue(), content_type="image/jpeg")
 
 
 @pytest.mark.django_db
@@ -824,6 +834,36 @@ def test_whisky_create_post_valid(client, user):
 
 
 @pytest.mark.django_db
+def test_whisky_create_saves_front_label_image(client, user, clear_image_folder):
+    client.force_login(user)
+    response = client.post(
+        reverse("whisky-add"),
+        {
+            "name": "Lagavulin 16",
+            "whisky_type": "SM",
+            "abv": 43.0,
+            "size": "0.70",
+            "country": "GB",
+            "comment": "",
+            "price": "",
+            "rating": "",
+            "image_front_label": _test_image_upload(),
+        },
+        follow=True,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    whisky = Whisky.objects.get(user=user, name="Lagavulin 16")
+    assert (
+        WhiskyImage.objects.filter(
+            whisky=whisky,
+            image_type=WhiskyImage.ImageType.LABEL_FRONT,
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
 def test_whisky_create_post_empty(client, user):
     """Test that submitting an empty form shows validation errors."""
     client.force_login(user)
@@ -913,6 +953,55 @@ def test_whisky_stock_add_uses_shared_template(client, user, whisky_factory):
     assertTemplateUsed(response, "whisky/stock_add.html")
     assertTemplateUsed(response, "core/stock_add.html")
     assert response.context["whisky"].pk == whisky.pk
+
+
+@pytest.mark.django_db
+def test_whisky_update_replaces_front_image_and_clears_back_image(
+    client, user, whisky_factory, clear_image_folder
+):
+    whisky = whisky_factory(user=user)
+    front_image = WhiskyImage.objects.create(
+        whisky=whisky,
+        user=user,
+        image=_test_image_upload("front-existing.jpg"),
+        image_type=WhiskyImage.ImageType.LABEL_FRONT,
+    )
+    WhiskyImage.objects.create(
+        whisky=whisky,
+        user=user,
+        image=_test_image_upload("back-existing.jpg"),
+        image_type=WhiskyImage.ImageType.LABEL_BACK,
+    )
+
+    client.force_login(user)
+    response = client.post(
+        reverse("whisky-edit", kwargs={"pk": whisky.pk}),
+        {
+            "name": whisky.name,
+            "whisky_type": whisky.whisky_type,
+            "abv": whisky.abv,
+            "size": whisky.size,
+            "country": whisky.country,
+            "comment": whisky.comment,
+            "price": whisky.price or "",
+            "rating": whisky.rating or "",
+            "image_front_label": _test_image_upload("front-replacement.jpg"),
+            "image_back_label-clear": "on",
+        },
+        follow=True,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    front_images = WhiskyImage.objects.filter(
+        whisky=whisky,
+        image_type=WhiskyImage.ImageType.LABEL_FRONT,
+    )
+    assert front_images.count() == 1
+    assert front_images.get().pk != front_image.pk
+    assert not WhiskyImage.objects.filter(
+        whisky=whisky,
+        image_type=WhiskyImage.ImageType.LABEL_BACK,
+    ).exists()
 
 
 @pytest.mark.django_db

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -1206,9 +1206,10 @@ class BaseBeverageUpdateView(RequireMemberMixin, FormView):
             pk=self.kwargs["pk"],
             household=household,
         )
-        self.process_form_data(beverage, self.request.user, form.cleaned_data)
-        self.sync_form_images(beverage, self.request.user, form.cleaned_data)
-        log_update(self.request.user, beverage)
+        with transaction.atomic():
+            self.process_form_data(beverage, self.request.user, form.cleaned_data)
+            self.sync_form_images(beverage, self.request.user, form.cleaned_data)
+            log_update(self.request.user, beverage)
         self.success_url = reverse_lazy(
             self.detail_url_name, kwargs={"pk": beverage.pk}
         )
@@ -1448,20 +1449,23 @@ class BaseBeverageCreateView(RequireMemberMixin, FormView):
                     )
 
         household = get_active_household(self.request.user)
-        beverage, created = self.process_form_data(
-            self.request.user, household, form.cleaned_data
-        )
-        self.create_form_images(beverage, self.request.user, form.cleaned_data)
+        with transaction.atomic():
+            beverage, created = self.process_form_data(
+                self.request.user, household, form.cleaned_data
+            )
+            self.create_form_images(beverage, self.request.user, form.cleaned_data)
 
-        if created:
-            log_create(self.request.user, beverage)
+            if created:
+                log_create(self.request.user, beverage)
 
-        self.post_create(beverage, created)
+            self.post_create(beverage, created)
 
-        # Link extraction log to created beverage and record corrections
-        extraction_result = self.request.session.get("extraction_result")
-        if extraction_result and created:
-            self._link_extraction_log(beverage, form.cleaned_data, extraction_result)
+            # Link extraction log to created beverage and record corrections
+            extraction_result = self.request.session.get("extraction_result")
+            if extraction_result and created:
+                self._link_extraction_log(
+                    beverage, form.cleaned_data, extraction_result
+                )
 
         # Clear session data
         for key in ("scanned_label", "extraction_result"):

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -755,6 +755,8 @@ class BaseDetailView(RequireHouseholdMixin, DetailView):
     select_related_fields = ()
     prefetch_related_fields = ()
     storage_item_reverse = None  # e.g. "storageitem" or "whiskystorageitem"
+    extraction_log_model = None
+    extraction_log_fk_name = None
 
     def get_queryset(self):
         qs = super().get_queryset()
@@ -792,11 +794,26 @@ class BaseDetailView(RequireHouseholdMixin, DetailView):
             )
         )
         context["duplicates"] = duplicates
+        extraction_log = self.get_extraction_log(beverage)
+        if extraction_log:
+            context["extraction_log"] = extraction_log
 
         # Track recently viewed beverages in session
         _track_recent_view(self.request, beverage)
 
         return context
+
+    def get_extraction_log(self, beverage):
+        if not self.extraction_log_model or not self.extraction_log_fk_name:
+            return None
+
+        return (
+            self.extraction_log_model.objects.filter(
+                **{self.extraction_log_fk_name: beverage, "was_successful": True}
+            )
+            .order_by("-created")
+            .first()
+        )
 
 
 MAX_RECENT_VIEWS = 8
@@ -1105,6 +1122,48 @@ class BaseBeverageUpdateView(RequireMemberMixin, FormView):
     image_related_name = None  # e.g. "wineimage_set" or "images"
     detail_url_name = None  # e.g. "wine-detail" or "whisky-detail"
 
+    def get_form_image_config(self):
+        form_class = self.get_form_class()
+        return (
+            getattr(form_class, "image_model", None),
+            getattr(form_class, "image_fields_map", {}),
+            getattr(form_class, "beverage_fk_name", None),
+        )
+
+    def sync_form_images(self, beverage, user, cleaned_data):
+        image_model, image_fields_map, beverage_fk_name = self.get_form_image_config()
+        if not image_model or not beverage_fk_name:
+            return
+
+        for field_name, image_type in image_fields_map.items():
+            image = cleaned_data.get(field_name)
+            existing_image = image_model.objects.filter(
+                **{
+                    beverage_fk_name: beverage,
+                    "user": user,
+                    "image_type": image_type,
+                }
+            ).first()
+
+            if image is False:
+                if existing_image:
+                    existing_image.image.delete()
+                    existing_image.delete()
+                continue
+
+            if image and not hasattr(image, "instance"):
+                if existing_image:
+                    existing_image.image.delete()
+                    existing_image.delete()
+                image_model.objects.create(
+                    **{
+                        beverage_fk_name: beverage,
+                        "image": image,
+                        "user": user,
+                        "image_type": image_type,
+                    }
+                )
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         if "user" not in kwargs:
@@ -1148,6 +1207,7 @@ class BaseBeverageUpdateView(RequireMemberMixin, FormView):
             household=household,
         )
         self.process_form_data(beverage, self.request.user, form.cleaned_data)
+        self.sync_form_images(beverage, self.request.user, form.cleaned_data)
         log_update(self.request.user, beverage)
         self.success_url = reverse_lazy(
             self.detail_url_name, kwargs={"pk": beverage.pk}
@@ -1193,6 +1253,8 @@ class BaseBeverageCreateView(RequireMemberMixin, FormView):
     vision_confidence_field_map = {}
     vision_create_fields = ()
     vision_fk_name_fields = {}
+    extraction_log_model = None
+    extraction_log_fk_name = None
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -1389,6 +1451,7 @@ class BaseBeverageCreateView(RequireMemberMixin, FormView):
         beverage, created = self.process_form_data(
             self.request.user, household, form.cleaned_data
         )
+        self.create_form_images(beverage, self.request.user, form.cleaned_data)
 
         if created:
             log_create(self.request.user, beverage)
@@ -1428,6 +1491,33 @@ class BaseBeverageCreateView(RequireMemberMixin, FormView):
     def process_form_data(self, user, household, cleaned_data):
         raise NotImplementedError
 
+    def get_form_image_config(self):
+        form_class = self.get_form_class()
+        return (
+            getattr(form_class, "image_model", None),
+            getattr(form_class, "image_fields_map", {}),
+            getattr(form_class, "beverage_fk_name", None),
+        )
+
+    def create_form_images(self, beverage, user, cleaned_data):
+        image_model, image_fields_map, beverage_fk_name = self.get_form_image_config()
+        if not image_model or not beverage_fk_name:
+            return
+
+        for field_name, image_type in image_fields_map.items():
+            image = cleaned_data.get(field_name)
+            if not image:
+                continue
+
+            image_model.objects.get_or_create(
+                **{
+                    beverage_fk_name: beverage,
+                    "image": image,
+                    "user": user,
+                    "image_type": image_type,
+                }
+            )
+
     def post_create(self, beverage, created):
         """Hook for post-creation processing. Override per app."""
         pass
@@ -1435,7 +1525,40 @@ class BaseBeverageCreateView(RequireMemberMixin, FormView):
     def _link_extraction_log(self, beverage, cleaned_data, extraction_result):
         """Link the most recent extraction log to the created beverage
         and record any user corrections."""
-        pass  # Override per app
+        if not self.extraction_log_model or not self.extraction_log_fk_name:
+            return
+
+        try:
+            log = (
+                self.extraction_log_model.objects.filter(
+                    **{
+                        "user": self.request.user,
+                        f"{self.extraction_log_fk_name}__isnull": True,
+                    }
+                )
+                .order_by("-created")
+                .first()
+            )
+            if log:
+                extracted_data = extraction_result.get("extracted_data", {})
+                corrections = self._detect_corrections(cleaned_data, extracted_data)
+                setattr(log, self.extraction_log_fk_name, beverage)
+                log.was_successful = True
+                if corrections:
+                    log.user_corrections = corrections
+                log.save(
+                    update_fields=[
+                        self.extraction_log_fk_name,
+                        "was_successful",
+                        "user_corrections",
+                    ]
+                )
+        except Exception:
+            logger.exception(
+                "Failed to link extraction log to %s %s",
+                self.beverage_label,
+                beverage.pk,
+            )
 
     @staticmethod
     def _detect_corrections(cleaned_data, extracted_data):

--- a/wine_cellar/apps/whisky/views.py
+++ b/wine_cellar/apps/whisky/views.py
@@ -404,6 +404,8 @@ class WhiskyCreateView(BaseBeverageCreateView):
         "region_name": "region",
         "bottler_name": "bottler",
     }
+    extraction_log_model = WhiskyVisionExtractionLog
+    extraction_log_fk_name = "whisky"
 
     def resolve_extracted_data(self, result_data, initial):
         _resolve_whisky_extracted_fks(result_data)
@@ -482,25 +484,6 @@ class WhiskyCreateView(BaseBeverageCreateView):
                 defaults={"whisky": whisky, "household": household},
             )
 
-        # Handle images
-        image_front_label = cleaned_data.get("image_front_label")
-        if image_front_label:
-            WhiskyImage.objects.get_or_create(
-                image=image_front_label,
-                whisky=whisky,
-                user=user,
-                image_type=WhiskyImage.ImageType.LABEL_FRONT,
-            )
-
-        image_back_label = cleaned_data.get("image_back_label")
-        if image_back_label:
-            WhiskyImage.objects.get_or_create(
-                image=image_back_label,
-                whisky=whisky,
-                user=user,
-                image_type=WhiskyImage.ImageType.LABEL_BACK,
-            )
-
         # Handle storage (add bottle to cellar) if provided
         storage = cleaned_data.get("storage")
         if storage:
@@ -530,29 +513,6 @@ class WhiskyCreateView(BaseBeverageCreateView):
             )
 
         return whisky, created
-
-    def _link_extraction_log(self, beverage, cleaned_data, extraction_result):
-        """Link the most recent WhiskyVisionExtractionLog to the created whisky."""
-        from wine_cellar.apps.whisky.models import WhiskyVisionExtractionLog
-
-        try:
-            log = (
-                WhiskyVisionExtractionLog.objects.filter(
-                    user=self.request.user, whisky__isnull=True
-                )
-                .order_by("-created")
-                .first()
-            )
-            if log:
-                extracted_data = extraction_result.get("extracted_data", {})
-                corrections = self._detect_corrections(cleaned_data, extracted_data)
-                log.whisky = beverage
-                log.was_successful = True
-                if corrections:
-                    log.user_corrections = corrections
-                log.save(update_fields=["whisky", "was_successful", "user_corrections"])
-        except Exception:
-            logger.exception("Failed to link extraction log to whisky %s", beverage.pk)
 
 
 class WhiskyUpdateView(BaseBeverageUpdateView):
@@ -632,49 +592,6 @@ class WhiskyUpdateView(BaseBeverageUpdateView):
                 defaults={"whisky": whisky, "household": whisky.household},
             )
 
-        # Handle images
-        image_front_label = cleaned_data.get("image_front_label")
-        existing_front = WhiskyImage.objects.filter(
-            whisky=whisky, user=user, image_type=WhiskyImage.ImageType.LABEL_FRONT
-        ).first()
-
-        if image_front_label is False:
-            # User explicitly cleared the image
-            if existing_front:
-                existing_front.image.delete()
-                existing_front.delete()
-        elif image_front_label and not hasattr(image_front_label, "instance"):
-            # User uploaded a new image
-            if existing_front:
-                existing_front.image.delete()
-                existing_front.delete()
-            WhiskyImage.objects.create(
-                image=image_front_label,
-                whisky=whisky,
-                user=user,
-                image_type=WhiskyImage.ImageType.LABEL_FRONT,
-            )
-
-        image_back_label = cleaned_data.get("image_back_label")
-        existing_back = WhiskyImage.objects.filter(
-            whisky=whisky, user=user, image_type=WhiskyImage.ImageType.LABEL_BACK
-        ).first()
-
-        if image_back_label is False:
-            if existing_back:
-                existing_back.image.delete()
-                existing_back.delete()
-        elif image_back_label and not hasattr(image_back_label, "instance"):
-            if existing_back:
-                existing_back.image.delete()
-                existing_back.delete()
-            WhiskyImage.objects.create(
-                image=image_back_label,
-                whisky=whisky,
-                user=user,
-                image_type=WhiskyImage.ImageType.LABEL_BACK,
-            )
-
 
 class WhiskyDetailView(BaseDetailView):
     template_name = "whisky/whisky_detail.html"
@@ -682,6 +599,8 @@ class WhiskyDetailView(BaseDetailView):
     select_related_fields = ("distillery", "region", "bottler", "source")
     prefetch_related_fields = ("cask_history", "images", "barcodes", "collections")
     storage_item_reverse = "whiskystorageitem"
+    extraction_log_model = WhiskyVisionExtractionLog
+    extraction_log_fk_name = "whisky"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -689,17 +608,6 @@ class WhiskyDetailView(BaseDetailView):
         context["all_collections"] = Collection.objects.filter(
             household=household
         ).order_by("name")
-        from wine_cellar.apps.whisky.models import WhiskyVisionExtractionLog
-
-        extraction_log = (
-            WhiskyVisionExtractionLog.objects.filter(
-                whisky=self.object, was_successful=True
-            )
-            .order_by("-created")
-            .first()
-        )
-        if extraction_log:
-            context["extraction_log"] = extraction_log
         return context
 
 

--- a/wine_cellar/apps/wine/views/wine_crud.py
+++ b/wine_cellar/apps/wine/views/wine_crud.py
@@ -24,8 +24,14 @@ from wine_cellar.apps.storage.models import StorageItem
 from wine_cellar.apps.storage.utils import with_removal_sort_date
 from wine_cellar.apps.user.views import get_active_household
 from wine_cellar.apps.wine.filters import WineFilter
-from wine_cellar.apps.wine.forms import WineBaseForm, WineEditForm, WineForm
-from wine_cellar.apps.wine.models import Collection, Wine, WineBarcode, WineImage
+from wine_cellar.apps.wine.forms import WineEditForm, WineForm
+from wine_cellar.apps.wine.models import (
+    Collection,
+    VisionExtractionLog,
+    Wine,
+    WineBarcode,
+    WineImage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +133,8 @@ class WineCreateView(BaseBeverageCreateView):
         "appellation": "appellation",
     }
     vision_create_fields = ("grapes", "vineyard")
+    extraction_log_model = VisionExtractionLog
+    extraction_log_fk_name = "wine"
 
     def resolve_extracted_data(self, result_data, initial):
         # Vineyard: wrap string in list for form
@@ -191,29 +199,6 @@ class WineCreateView(BaseBeverageCreateView):
                 if confidence in ("high", "medium"):
                     extracted_data = extraction_result.get("extracted_data", {})
                     self._apply_auto_crop(beverage, extracted_data)
-
-    def _link_extraction_log(self, beverage, cleaned_data, extraction_result):
-        """Link the most recent VisionExtractionLog to the created wine."""
-        from wine_cellar.apps.wine.models import VisionExtractionLog
-
-        try:
-            log = (
-                VisionExtractionLog.objects.filter(
-                    user=self.request.user, wine__isnull=True
-                )
-                .order_by("-created")
-                .first()
-            )
-            if log:
-                extracted_data = extraction_result.get("extracted_data", {})
-                corrections = self._detect_corrections(cleaned_data, extracted_data)
-                log.wine = beverage
-                log.was_successful = True
-                if corrections:
-                    log.user_corrections = corrections
-                log.save(update_fields=["wine", "was_successful", "user_corrections"])
-        except Exception:
-            logger.exception("Failed to link extraction log to wine %s", beverage.pk)
 
     @staticmethod
     def _apply_auto_crop(wine, extracted_data):
@@ -323,13 +308,6 @@ class WineCreateView(BaseBeverageCreateView):
         wine.source.set(source)
         wine.attributes.set(attributes)
 
-        for form_field, image_type in WineBaseForm.image_fields_map.items():
-            image = cleaned_data.get(form_field)
-            if image:
-                WineImage.objects.get_or_create(
-                    image=image, wine=wine, user=user, image_type=image_type
-                )
-
         storage = cleaned_data.get("storage")
         if storage:
             row = cleaned_data.get("row")
@@ -433,24 +411,6 @@ class WineUpdateView(BaseBeverageUpdateView):
         wine.attributes.set(attributes)
         wine.source.set(source)
 
-        for form_field, image_type in WineBaseForm.image_fields_map.items():
-            image = cleaned_data.get(form_field)
-            existing_image = WineImage.objects.filter(
-                wine=wine, user=user, image_type=image_type
-            ).first()
-
-            if image is False:
-                if existing_image:
-                    existing_image.image.delete()
-                    existing_image.delete()
-            elif image and not hasattr(image, "instance"):
-                if existing_image:
-                    existing_image.image.delete()
-                    existing_image.delete()
-                WineImage.objects.create(
-                    image=image, wine=wine, user=user, image_type=image_type
-                )
-
 
 class WineDetailView(BaseDetailView):
     template_name = "wine_detail.html"
@@ -467,22 +427,15 @@ class WineDetailView(BaseDetailView):
         "collections",
     )
     storage_item_reverse = "storageitem"
+    extraction_log_model = VisionExtractionLog
+    extraction_log_fk_name = "wine"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        from wine_cellar.apps.wine.models import VisionExtractionLog
-
         household = get_active_household(self.request.user)
         context["all_collections"] = Collection.objects.filter(
             household=household
         ).order_by("name")
-        extraction_log = (
-            VisionExtractionLog.objects.filter(wine=self.object, was_successful=True)
-            .order_by("-created")
-            .first()
-        )
-        if extraction_log:
-            context["extraction_log"] = extraction_log
 
         removed_bottles = with_removal_sort_date(
             self.object.storageitem_set.filter(deleted=True)


### PR DESCRIPTION
## Summary
- move shared extraction-log linking and detail lookup into the base beverage views
- move shared create/update label-image syncing into reusable base helpers
- trim wine and whisky subclasses and add regression coverage for the deduped paths

## Testing
- make lint
- make pytest
- make whisky-pytest