### PR TITLE
Prepopulate selected bottle on record drink

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -666,6 +666,22 @@ class TestDrinkRecordCreateView:
         assert r.status_code == HTTPStatus.OK
         assert r.context["beverage"].pk == wine.pk
 
+    def test_get_preselects_storage_item_from_query_param(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        wine = wine_factory(user=user)
+        storage = user.storage_set.first()
+        item = storage_item_factory(wine=wine, storage=storage, user=user)
+        client.force_login(user)
+
+        r = client.get(
+            reverse("drink-record-add", kwargs={"pk": wine.pk}),
+            {"storage_item": item.pk},
+        )
+
+        assert r.status_code == HTTPStatus.OK
+        assert r.context["form"]["storage_item"].value() == item.pk
+
     def test_get_defaults_date_consumed_to_today(self, client, user, wine_factory):
         wine = wine_factory(user=user)
         client.force_login(user)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -985,6 +985,28 @@ def test_drink_record_without_bottle_still_works(client, user, wine_factory):
 
 
 @pytest.mark.django_db
+def test_wine_detail_record_drink_link_preserves_selected_storage_item(
+    client, user, wine_factory, storage_item_factory
+):
+    wine = wine_factory(user=user)
+    storage = user.storage_set.first()
+    bottle = storage_item_factory(wine=wine, storage=storage, user=user)
+    client.force_login(user)
+
+    response = client.get(
+        reverse("wine-detail", kwargs={"pk": wine.pk}),
+        {"storage_item": bottle.pk},
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    expected_drink_url = (
+        reverse("drink-record-add", kwargs={"pk": wine.pk})
+        + f"?storage_item={bottle.pk}"
+    )
+    assert f'href="{expected_drink_url}"' in response.content.decode()
+
+
+@pytest.mark.django_db
 def test_form_shows_only_available_bottles(
     client, user, wine_factory, storage_item_factory
 ):

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -607,6 +607,34 @@ def test_whisky_detail_loads(client, user, whisky_factory):
 
 
 @pytest.mark.django_db
+def test_whisky_detail_record_drink_link_preserves_selected_storage_item(
+    client, user, whisky_storage_item_factory
+):
+    household = user.user_settings.active_household
+    bottle = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky__user=user,
+        whisky__household=household,
+    )
+    client.force_login(user)
+
+    response = client.get(
+        reverse("whisky-detail", kwargs={"pk": bottle.whisky.pk}),
+        {"storage_item": bottle.pk},
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    expected_drink_url = (
+        reverse("drink-record-add", kwargs={"pk": bottle.whisky.pk})
+        + f"?storage_item={bottle.pk}"
+    )
+    assert f'href="{expected_drink_url}"' in response.content.decode()
+
+
+@pytest.mark.django_db
 def test_whisky_detail_uses_latest_successful_extraction_log(
     client, user, whisky_factory
 ):

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -420,6 +420,16 @@ class BaseDrinkRecordCreateView(RequireMemberMixin, FormView):
     beverage_fk_name = None  # "wine" or "whisky"
     detail_url_name = None  # e.g. "wine-detail" or "whisky-detail"
 
+    def get_initial(self):
+        initial = super().get_initial()
+        storage_item_pk = self.request.GET.get("storage_item")
+        if storage_item_pk:
+            try:
+                initial["storage_item"] = int(storage_item_pk)
+            except (TypeError, ValueError):
+                pass
+        return initial
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         household = get_active_household(self.request.user)

--- a/wine_cellar/apps/whisky/templates/whisky/whisky_detail.html
+++ b/wine_cellar/apps/whisky/templates/whisky/whisky_detail.html
@@ -290,7 +290,7 @@
                     <div>
                         <a href="{% url 'stock-add' whisky.pk %}"
                            class="pure-button button__neutral"><i class="fa-regular fa-plus"></i> <span>Add bottle</span></a>
-                        <a href="{% url 'drink-record-add' whisky.pk %}"
+                        <a href="{% url 'drink-record-add' whisky.pk %}{% if request.GET.storage_item %}?storage_item={{ request.GET.storage_item|urlencode }}{% endif %}"
                            class="pure-button button__neutral"><i class="fa-solid fa-whiskey-glass"></i> <span>Record Drink</span></a>
                         <a href="{% url 'reorder-reminder-add' whisky.pk %}"
                            class="pure-button button__neutral"><i class="fa-solid fa-bell"></i> <span>Reorder Alert</span></a>

--- a/wine_cellar/apps/wine/templates/wine_detail.html
+++ b/wine_cellar/apps/wine/templates/wine_detail.html
@@ -220,7 +220,7 @@
                     <div>
                         <a href="{% url 'stock-add' wine.pk %}"
                            class="pure-button button__neutral"><i class="fa-regular fa-plus"></i> <span>Add bottle</span></a>
-                        <a href="{% url 'drink-record-add' wine.pk %}"
+                        <a href="{% url 'drink-record-add' wine.pk %}{% if request.GET.storage_item %}?storage_item={{ request.GET.storage_item|urlencode }}{% endif %}"
                            class="pure-button button__neutral"><i class="fa-solid fa-wine-glass"></i> <span>Record Drink</span></a>
                         <a href="{% url 'reorder-reminder-add' wine.pk %}"
                            class="pure-button button__neutral"><i class="fa-solid fa-bell"></i> <span>Reorder Alert</span></a>

--- a/wine_cellar/react/storage_grid.tsx
+++ b/wine_cellar/react/storage_grid.tsx
@@ -102,9 +102,14 @@ interface TooltipProps {
     itemUrlPrefix: string;
 }
 
+const getBottleDetailUrl = (itemUrlPrefix: string, wine: WineInfo): string => (
+    `${itemUrlPrefix}${wine.id}/?storage_item=${encodeURIComponent(String(wine.item_id))}`
+);
+
 const Tooltip: React.FC<TooltipProps> = ({ wine, position, itemUrlPrefix }) => {
     const tooltipRef = React.useRef<HTMLDivElement>(null);
     const [adjustedPosition, setAdjustedPosition] = React.useState({ x: position.x, y: position.y });
+    const detailUrl = getBottleDetailUrl(itemUrlPrefix, wine);
 
     React.useLayoutEffect(() => {
         if (tooltipRef.current) {
@@ -145,7 +150,7 @@ const Tooltip: React.FC<TooltipProps> = ({ wine, position, itemUrlPrefix }) => {
             }}
         >
             <a
-                href={`${itemUrlPrefix}${wine.id}/`}
+                href={detailUrl}
                 className="tooltip__name tooltip__name--link"
                 onClick={(e) => {
                     e.stopPropagation();
@@ -153,7 +158,7 @@ const Tooltip: React.FC<TooltipProps> = ({ wine, position, itemUrlPrefix }) => {
                 onTouchEnd={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    window.location.href = `${itemUrlPrefix}${wine.id}/`;
+                    window.location.href = detailUrl;
                 }}
             >
                 {wine.name}


### PR DESCRIPTION
## Summary
- carry the selected storage item from the storage grid into the beverage detail page
- preserve that selected bottle in the Record Drink link so the drink form preselects it
- cover the shared create view plus wine and whisky detail link behavior with tests