### PR TITLE
fix whisky cask type autofill

### DIFF
--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -724,6 +724,17 @@ def test_whisky_create_get(client, user):
 
 
 @pytest.mark.django_db
+def test_whisky_create_marks_cask_type_as_creatable_for_vision_autofill(client, user):
+    """Whisky vision autofill should mark cask type as a creatable select."""
+    client.force_login(user)
+
+    response = client.get(reverse("whisky-add"))
+
+    assert response.status_code == HTTPStatus.OK
+    assert "cask_type" in response.context["vision_extraction_config"]["createFields"]
+
+
+@pytest.mark.django_db
 def test_whisky_create_prefills_distillery_when_scan_returns_full_whisky_name(
     client, user, distillery_factory
 ):

--- a/wine_cellar/apps/whisky/views.py
+++ b/wine_cellar/apps/whisky/views.py
@@ -399,6 +399,7 @@ class WhiskyCreateView(BaseBeverageCreateView):
         "bottler_series": "bottler_series",
         "barcode": "barcode",
     }
+    vision_create_fields = ("cask_type",)
     vision_fk_name_fields = {
         "distillery_name": "distillery",
         "region_name": "region",


### PR DESCRIPTION
## Summary
- mark whisky cask_type as a creatable field in vision autofill config
- allow extracted custom cask types to populate the add form reliably
- add a regression test for the create page vision config
