### PR TITLE
add whisky bottle status multi-filter

### DIFF
--- a/tests/whisky/test_search_filter.py
+++ b/tests/whisky/test_search_filter.py
@@ -202,7 +202,8 @@ if os.environ.get("CELLAR_APP_TYPE") == "whisky":
 
             filt = self._filter(user, fill_level=["UN", "OP"])
 
-            assert list(filt.qs) == [unopened, opened]
+            assert filt.qs.count() == 2
+            assert {item.pk for item in filt.qs} == {unopened.pk, opened.pk}
             assert dreg not in filt.qs
 
         def test_show_used_default_excludes_deleted(

--- a/tests/whisky/test_search_filter.py
+++ b/tests/whisky/test_search_filter.py
@@ -181,6 +181,30 @@ if os.environ.get("CELLAR_APP_TYPE") == "whisky":
 
             assert tom_config["maxOptions"] is None
 
+        def test_fill_level_filter_supports_multiple_selected_levels(
+            self, user, whisky_storage_item_factory
+        ):
+            unopened = self._create_storage_item(
+                user,
+                whisky_storage_item_factory,
+                fill_level="UN",
+            )
+            opened = self._create_storage_item(
+                user,
+                whisky_storage_item_factory,
+                fill_level="OP",
+            )
+            dreg = self._create_storage_item(
+                user,
+                whisky_storage_item_factory,
+                fill_level="DR",
+            )
+
+            filt = self._filter(user, fill_level=["UN", "OP"])
+
+            assert list(filt.qs) == [unopened, opened]
+            assert dreg not in filt.qs
+
         def test_show_used_default_excludes_deleted(
             self, user, whisky_storage_item_factory
         ):

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -230,6 +230,53 @@ def test_bottle_list_filters_by_whisky_name(client, user, whisky_storage_item_fa
 
 
 @pytest.mark.django_db
+def test_bottle_list_filters_by_multiple_fill_levels(
+    client, user, whisky_storage_item_factory
+):
+    """Bottle list should allow multiple fill level selections."""
+    household = user.user_settings.active_household
+    unopened = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky__user=user,
+        whisky__household=household,
+        fill_level=FillLevel.UNOPENED,
+    )
+    opened = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky__user=user,
+        whisky__household=household,
+        fill_level=FillLevel.OPENED,
+    )
+    dreg = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        storage__user=user,
+        storage__household=household,
+        whisky__user=user,
+        whisky__household=household,
+        fill_level=FillLevel.DREG,
+    )
+
+    client.force_login(user)
+    r = client.get(
+        reverse("bottle-list"),
+        {"fill_level": [FillLevel.UNOPENED, FillLevel.OPENED]},
+    )
+
+    assert r.status_code == HTTPStatus.OK
+    bottles = list(r.context["bottles"])
+    assert unopened in bottles
+    assert opened in bottles
+    assert dreg not in bottles
+
+
+@pytest.mark.django_db
 def test_whisky_list_defaults_to_in_stock_and_oldest_first(
     client, user, whisky_factory, whisky_storage_item_factory
 ):

--- a/wine_cellar/apps/whisky/filters.py
+++ b/wine_cellar/apps/whisky/filters.py
@@ -269,8 +269,8 @@ class WhiskyStorageItemFilter(BaseStockItemFilter):
         lookup_expr="icontains",
         label="Whisky Name",
     )
-    fill_level = ChoiceFilter(
-        choices=[("", "All")] + list(FillLevel.choices),
+    fill_level = MultipleChoiceFilter(
+        choices=list(FillLevel.choices),
         label="Fill Level",
     )
     is_gift = ChoiceFilter(

--- a/wine_cellar/apps/whisky/forms.py
+++ b/wine_cellar/apps/whisky/forms.py
@@ -721,6 +721,15 @@ class WhiskyStorageItemFilterForm(TomSelectMixin, forms.Form):
                     placeholder="",
                     search=True,
                 )
+        if "fill_level" in self.fields:
+            self.set_tom_config(
+                name="fill_level",
+                create=False,
+                max_options=-1,
+                clear=False,
+                placeholder="",
+                closeAfterSelect=False,
+            )
 
 
 class WhiskyStockAddForm(TomSelectMixin, forms.Form):


### PR DESCRIPTION
## Summary
- allow selecting multiple whisky bottle statuses in the bottle list filter
- wire the fill level filter field for multi-select TomSelect behavior
- add regression coverage for filter logic and bottle list query params
