### PR TITLE
docs: clarify current background task setup

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -37,12 +37,11 @@ For production, configure a real email backend:
 | `EMAIL_USE_TLS` | No | `True` | Use TLS for SMTP connection |
 | `DEFAULT_FROM_EMAIL` | No | - | Default sender email address |
 
-## Celery (Background Tasks)
+## Background Tasks
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `CELERY_BROKER_URL` | No | - | Message broker URL (e.g., `redis://localhost:6379/0`) |
-| `CELERY_RESULT_BACKEND` | No | - | Result backend URL |
+Background work is currently handled with Django management commands plus host
+cron scheduling. There are no task-queue-specific environment variables to
+configure.
 
 ## Logging
 
@@ -75,8 +74,6 @@ EMAIL_HOST_USER=winecellar@example.com
 EMAIL_HOST_PASSWORD=your-email-password
 DEFAULT_FROM_EMAIL=Wine Cellar <noreply@example.com>
 
-# Celery (production)
-CELERY_BROKER_URL=redis://localhost:6379/0
 ```
 
 ## Security Notes

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -41,7 +41,14 @@ For production, configure a real email backend:
 
 Background work is currently handled with Django management commands plus host
 cron scheduling. There are no task-queue-specific environment variables to
-configure.
+configure, but Docker deployments still use `REDIS_URL` for the shared Django
+cache.
+
+## Redis Cache (Docker)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `REDIS_URL` | No | `redis://redis:6379/1` | Redis cache URL used by Docker settings (`django.core.cache.backends.redis.RedisCache`) |
 
 ## Logging
 
@@ -73,6 +80,9 @@ EMAIL_PORT=587
 EMAIL_HOST_USER=winecellar@example.com
 EMAIL_HOST_PASSWORD=your-email-password
 DEFAULT_FROM_EMAIL=Wine Cellar <noreply@example.com>
+
+# Redis cache (Docker production)
+REDIS_URL=redis://redis:6379/1
 
 ```
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -175,14 +175,16 @@ After upgrading, verify:
 2. **Login works**: Test authentication
 3. **Data intact**: Verify wine list loads
 4. **Features work**: Test barcode scanner, image upload
-5. **Background tasks**: Check Celery is running (if configured)
+5. **Background tasks**: If you use drink-by reminders, confirm the host cron
+   job that runs `python manage.py send_drink_reminders` is still configured
+   after the upgrade
 
 ```bash
 # Check application logs
 tail -f /var/log/winecellar/gunicorn.log
 
-# Check Celery logs (if using)
-tail -f /var/log/winecellar/celery.log
+# If you use drink-by reminders, inspect the reminder cron log
+tail -f /var/log/drink_reminders.log
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- remove stale Celery references from the environment guide
- point upgrade verification at the cron-managed send_drink_reminders job

## Issue triage
Issue #110 is no longer actionable as written. The current stack intentionally uses a management command plus host cron for drink reminders, Redis remains in the deployment for caching, and the other proposed queue consumers (price scraping, async thumbnail regeneration, general email jobs) are not implemented in the codebase today.

Refs #110