### PR TITLE
Improve key accessibility affordances

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,6 +31,16 @@ def test_homepage(client, user):
 
 
 @pytest.mark.django_db
+def test_base_template_includes_skip_link(client, user):
+    client.force_login(user)
+    r = client.get(reverse("homepage"), follow=True)
+    assert r.status_code == HTTPStatus.OK
+    content = r.content.decode()
+    assert 'href="#main-content"' in content
+    assert 'id="main-content"' in content
+
+
+@pytest.mark.django_db
 def test_homepage_stats(client, user, wine_factory, storage_item_factory):
     Wine.objects.filter(user=user).delete()
     wine = wine_factory(user=user, vintage=2020)
@@ -1140,6 +1150,24 @@ def test_stats_dashboard_purchase_trends(
     assert r.status_code == HTTPStatus.OK
     by_month = r.context_data["by_month"]
     assert len(by_month) >= 1
+
+
+@pytest.mark.django_db
+def test_stats_dashboard_charts_include_accessible_descriptions(
+    client, user, wine_factory, storage_item_factory
+):
+    Wine.objects.filter(user=user).delete()
+    storage = user.storage_set.first()
+    wine = wine_factory(user=user, wine_type="WH", country="FR", price=18.00)
+    storage_item_factory(wine=wine, storage=storage, price=None)
+    client.force_login(user)
+    r = client.get(reverse("stats-dashboard"))
+    assert r.status_code == HTTPStatus.OK
+    content = r.content.decode()
+    assert 'id="chartByTypeSummary"' in content
+    assert 'aria-describedby="chartByTypeSummary"' in content
+    assert 'aria-label="Bottles by country chart"' in content
+    assert 'aria-describedby="chartByStorageSummary"' in content
 
 
 @pytest.mark.django_db

--- a/wine_cellar/assets/css/storage.css
+++ b/wine_cellar/assets/css/storage.css
@@ -138,6 +138,17 @@
   background-color: var(--gray-50);
   transition: all var(--transition-fast);
   flex-shrink: 0;
+  padding: 0;
+  appearance: none;
+  font: inherit;
+}
+
+.storage-grid__cell:focus-visible,
+.storage-view-toggle__btn:focus-visible,
+.storage-grid__mode-btn:focus-visible,
+.storage-grid__cancel-btn:focus-visible {
+  outline: 3px solid var(--alert-info-border);
+  outline-offset: 2px;
 }
 
 /* Larger cells on mobile for better touch targets */
@@ -612,6 +623,10 @@
   border: 2px dashed var(--gray-300);
   opacity: 0.3;
   cursor: default;
+}
+
+.storage-grid__cell:disabled {
+  color: inherit;
 }
 
 @media (hover: hover) {

--- a/wine_cellar/assets/css/utility.css
+++ b/wine_cellar/assets/css/utility.css
@@ -18,6 +18,25 @@
   white-space: nowrap;
 }
 
+.skip-link {
+  position: fixed;
+  top: var(--spacing-sm);
+  left: var(--spacing-sm);
+  z-index: var(--z-modal);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--primary);
+  color: var(--white);
+  border-radius: var(--border-radius-sm);
+  box-shadow: var(--container-box-shadow);
+  transform: translateY(-200%);
+  transition: transform var(--transition-fast);
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
 .m-auto {
   margin: auto;
 }

--- a/wine_cellar/react/react_label_scanner.tsx
+++ b/wine_cellar/react/react_label_scanner.tsx
@@ -232,6 +232,7 @@ const LabelScanner: React.FC = () => {
                         type="button"
                         className="pure-button button__secondary"
                         onClick={capturePhoto}
+                        aria-label={`${translated.captureButton}. ${stepInstructions[currentStep]}`}
                     >
                         {translated.captureButton}
                     </button>
@@ -241,6 +242,7 @@ const LabelScanner: React.FC = () => {
                             type="button"
                             className="pure-button button__tertiary"
                             onClick={retakePhoto}
+                            aria-label={translated.retakeButton}
                         >
                             {translated.retakeButton}
                         </button>
@@ -249,6 +251,7 @@ const LabelScanner: React.FC = () => {
                                 type="button"
                                 className="pure-button button__secondary"
                                 onClick={nextPhoto}
+                                aria-label={translated.nextPhotoButton}
                             >
                                 {translated.nextPhotoButton}
                             </button>
@@ -257,6 +260,7 @@ const LabelScanner: React.FC = () => {
                                 type="button"
                                 className="pure-button button__secondary"
                                 onClick={submitAllImages}
+                                aria-label={translated.submitAllButton}
                             >
                                 {translated.submitAllButton}
                             </button>

--- a/wine_cellar/react/storage_grid.tsx
+++ b/wine_cellar/react/storage_grid.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import {
     DndContext,
@@ -11,8 +11,6 @@ import {
     useSensors,
     useDraggable,
     useDroppable,
-    Active,
-    Over,
 } from '@dnd-kit/core';
 import ErrorBoundary from './components/ErrorBoundary';
 
@@ -106,6 +104,107 @@ const getBottleDetailUrl = (itemUrlPrefix: string, wine: WineInfo): string => (
     `${itemUrlPrefix}${wine.id}/?storage_item=${encodeURIComponent(String(wine.item_id))}`
 );
 
+const getCellPositionFromElement = (element: HTMLElement): { clientX: number; clientY: number } => {
+    const rect = element.getBoundingClientRect();
+    return {
+        clientX: rect.left + (rect.width / 2),
+        clientY: rect.top + (rect.height / 2),
+    };
+};
+
+const focusGridCell = (currentTarget: HTMLElement, row: number, column: number) => {
+    const gridId = currentTarget.dataset.gridId;
+    if (!gridId) return;
+
+    const selector = `[data-grid-id="${gridId}"][data-row="${row}"][data-column="${column}"]`;
+    const nextCell = document.querySelector<HTMLElement>(selector);
+    nextCell?.focus();
+};
+
+const handleGridKeyDown = (
+    event: React.KeyboardEvent<HTMLElement>,
+    onActivate?: () => void,
+) => {
+    const currentRow = Number(event.currentTarget.dataset.row);
+    const currentColumn = Number(event.currentTarget.dataset.column);
+
+    switch (event.key) {
+    case 'ArrowUp':
+        event.preventDefault();
+        focusGridCell(event.currentTarget, currentRow - 1, currentColumn);
+        break;
+    case 'ArrowDown':
+        event.preventDefault();
+        focusGridCell(event.currentTarget, currentRow + 1, currentColumn);
+        break;
+    case 'ArrowLeft':
+        event.preventDefault();
+        focusGridCell(event.currentTarget, currentRow, currentColumn - 1);
+        break;
+    case 'ArrowRight':
+        event.preventDefault();
+        focusGridCell(event.currentTarget, currentRow, currentColumn + 1);
+        break;
+    case 'Home':
+        event.preventDefault();
+        focusGridCell(event.currentTarget, currentRow, 1);
+        break;
+    case 'End':
+        event.preventDefault();
+        focusGridCell(event.currentTarget, currentRow, Number(event.currentTarget.dataset.maxColumn));
+        break;
+    case 'Enter':
+    case ' ':
+        event.preventDefault();
+        onActivate?.();
+        break;
+    default:
+        break;
+    }
+};
+
+const getCellAriaLabel = (
+    cell: CellData,
+    storageName: string,
+    context: 'browse' | 'source' | 'destination',
+    hasSelectedBottle = false,
+): string => {
+    const location = `${storageName}, row ${cell.row}, column ${cell.column}`;
+
+    if (!cell.active) {
+        return `${location}. Unavailable cell.`;
+    }
+
+    if (cell.wine) {
+        const details = [
+            cell.wine.name,
+            cell.wine.vintage ? String(cell.wine.vintage) : null,
+            cell.wine.country || null,
+            cell.wine.wine_type || null,
+        ].filter(Boolean).join(', ');
+
+        if (context === 'source') {
+            return `${location}. ${details}. Press Enter to select this bottle to move.`;
+        }
+
+        if (context === 'destination') {
+            return `${location}. ${details}. Destination occupied. Choose an empty cell.`;
+        }
+
+        return `${location}. ${details}. Press Enter to open bottle details.`;
+    }
+
+    if (context === 'destination' && hasSelectedBottle) {
+        return `${location}. Empty cell. Press Enter to move the selected bottle here.`;
+    }
+
+    if (context === 'source') {
+        return `${location}. Empty cell. Select a bottle to move.`;
+    }
+
+    return `${location}. Empty cell.`;
+};
+
 const Tooltip: React.FC<TooltipProps> = ({ wine, position, itemUrlPrefix }) => {
     const tooltipRef = React.useRef<HTMLDivElement>(null);
     const [adjustedPosition, setAdjustedPosition] = React.useState({ x: position.x, y: position.y });
@@ -195,16 +294,26 @@ const RatingStars: React.FC<{ rating: number | null; maxRating?: number }> = ({ 
 interface DraggableCellProps {
     cell: CellData;
     storageId: number;
+    storageName: string;
+    gridId: string;
+    instructionsId: string;
+    maxColumn: number;
     onShowTooltip: (wine: WineInfo, e: { clientX: number; clientY: number }) => void;
     onHideTooltip: () => void;
+    onActivate: (cell: CellData) => void;
     isDragActive: boolean;
 }
 
 const DraggableCell: React.FC<DraggableCellProps> = ({
     cell,
     storageId,
+    storageName,
+    gridId,
+    instructionsId,
+    maxColumn,
     onShowTooltip,
     onHideTooltip,
+    onActivate,
     isDragActive,
 }) => {
     const id = `cell-${storageId}-${cell.row}-${cell.column}`;
@@ -224,7 +333,7 @@ const DraggableCell: React.FC<DraggableCellProps> = ({
     });
 
     // Combine refs
-    const setNodeRef = (node: HTMLDivElement | null) => {
+    const setNodeRef = (node: HTMLElement | null) => {
         setDragRef(node);
         setDropRef(node);
     };
@@ -255,7 +364,8 @@ const DraggableCell: React.FC<DraggableCellProps> = ({
     if (isOver && !hasWine && !isInactive) className += ' storage-grid__cell--drag-over';
 
     return (
-        <div
+        <button
+            type="button"
             ref={setNodeRef}
             className={className}
             {...listeners}
@@ -263,15 +373,29 @@ const DraggableCell: React.FC<DraggableCellProps> = ({
             onMouseEnter={handleMouseEnter}
             onMouseLeave={onHideTooltip}
             onTouchEnd={handleTouchEnd}
+            onFocus={(e) => {
+                if (cell.wine && !isDragActive) {
+                    onShowTooltip(cell.wine, getCellPositionFromElement(e.currentTarget));
+                }
+            }}
+            onBlur={onHideTooltip}
+            onKeyDown={(e) => handleGridKeyDown(e, () => onActivate(cell))}
             title={hasWine ? cell.wine!.name : `Empty (${cell.row}, ${cell.column})`}
+            aria-label={getCellAriaLabel(cell, storageName, 'browse')}
+            aria-describedby={instructionsId}
+            data-grid-id={gridId}
+            data-row={cell.row}
+            data-column={cell.column}
+            data-max-column={maxColumn}
+            disabled={isInactive}
         >
             {hasWine && !isDragging && (
                 <div className="storage-grid__bottle">
-                    <i className="fa-solid fa-wine-bottle" />
+                    <i className="fa-solid fa-wine-bottle" aria-hidden="true" />
                     <RatingStars rating={cell.wine!.rating} />
                 </div>
             )}
-        </div>
+        </button>
     );
 };
 
@@ -513,6 +637,11 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
     const sourceGrid = useMemo(() => sourceStorage ? buildGrid(sourceStorage) : [], [buildGrid, sourceStorage]);
     const targetGrid = useMemo(() => targetStorage ? buildGrid(targetStorage) : [], [buildGrid, targetStorage]);
 
+    const handleBrowseCellActivate = useCallback((cell: CellData) => {
+        if (!cell.wine) return;
+        window.location.href = getBottleDetailUrl(itemUrlPrefix, cell.wine);
+    }, [itemUrlPrefix]);
+
     // Early returns after all hooks
     if (loading) return <div className="storage-grid__loading">{translated.loading}</div>;
     if (error) return <div className="storage-grid__error">Error: {error}</div>;
@@ -555,7 +684,7 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                 ))}
             </div>
 
-            <div className="storage-grid__body">
+            <div className="storage-grid__body" role="group" aria-label={`${storage.name} storage grid`}>
                 {grid.map((row, rowIdx) => (
                     <div key={rowIdx} className="storage-grid__row">
                         <div className="storage-grid__row-label">{rowIdx + 1}</div>
@@ -569,12 +698,23 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                             const isInactive = !cell.active;
 
                             return (
-                                <div
+                                <button
+                                    type="button"
                                     key={`${rowIdx}-${colIdx}`}
                                     className={`storage-grid__cell${isInactive ? ' storage-grid__cell--inactive' : ''}${!isInactive && cell.wine ? ' storage-grid__cell--filled' : ''}${!isInactive && wineTypeClass ? ` storage-grid__cell--${wineTypeClass}` : ''}${isSelectedForMove ? ' storage-grid__cell--selected-for-move' : ''}${!isSource && !cell.wine && !isInactive && selectedBottle ? ' storage-grid__cell--drop-target' : ''}`}
-                                    onClick={() => !isInactive && handleMoveModeClick(cell, storage.id, isSource)}
+                                    onClick={() => {
+                                        if (!isInactive) {
+                                            handleMoveModeClick(cell, storage.id, isSource);
+                                        }
+                                    }}
                                     onMouseEnter={(e) => cell.wine && handleShowTooltip(cell.wine, e)}
                                     onMouseLeave={handleHideTooltip}
+                                    onFocus={(e) => {
+                                        if (cell.wine) {
+                                            handleShowTooltip(cell.wine, getCellPositionFromElement(e.currentTarget));
+                                        }
+                                    }}
+                                    onBlur={handleHideTooltip}
                                     onTouchStart={(e) => {
                                         if (cell.wine && e.touches.length > 0) {
                                             const touch = e.touches[0];
@@ -582,15 +722,33 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                                             e.stopPropagation();
                                         }
                                     }}
+                                    onKeyDown={(e) => handleGridKeyDown(e, () => {
+                                        if (!isInactive) {
+                                            handleMoveModeClick(cell, storage.id, isSource);
+                                        }
+                                    })}
                                     title={cell.wine ? cell.wine.name : `Empty (${cell.row}, ${cell.column})`}
+                                    aria-label={getCellAriaLabel(
+                                        cell,
+                                        storage.name,
+                                        isSource ? 'source' : 'destination',
+                                        Boolean(selectedBottle),
+                                    )}
+                                    aria-describedby="storage-grid-move-instructions"
+                                    aria-pressed={isSource && isSelectedForMove ? true : undefined}
+                                    data-grid-id={`${isSource ? 'source' : 'destination'}-${storage.id}`}
+                                    data-row={cell.row}
+                                    data-column={cell.column}
+                                    data-max-column={storage.columns}
+                                    disabled={isInactive}
                                 >
                                     {cell.wine && (
                                         <div className="storage-grid__bottle">
-                                            <i className="fa-solid fa-wine-bottle" />
+                                            <i className="fa-solid fa-wine-bottle" aria-hidden="true" />
                                             <RatingStars rating={cell.wine.rating} />
                                         </div>
                                     )}
-                                </div>
+                                </button>
                             );
                         })}
                     </div>
@@ -625,7 +783,10 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
 
                 {/* Message */}
                 {message && (
-                    <div className={`storage-grid__message storage-grid__message--${message.type}`}>
+                    <div
+                        className={`storage-grid__message storage-grid__message--${message.type}`}
+                        role={message.type === 'error' ? 'alert' : 'status'}
+                    >
                         {message.text}
                     </div>
                 )}
@@ -633,11 +794,15 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                 {/* Move mode hint */}
                 <div className="storage-grid__move-hint">
                     {selectedBottle ? (
-                        <><i className="fa-solid fa-hand-pointer" /> {translated.selectDestination}</>
+                        <><i className="fa-solid fa-hand-pointer" aria-hidden="true" /> {translated.selectDestination}</>
                     ) : (
-                        <><i className="fa-solid fa-wine-bottle" /> {translated.selectBottle}</>
+                        <><i className="fa-solid fa-wine-bottle" aria-hidden="true" /> {translated.selectBottle}</>
                     )}
                 </div>
+                <p id="storage-grid-move-instructions" className="visually-hidden">
+                    Use Tab or the arrow keys to move between cells. Press Enter to select a bottle in
+                    the source grid, then press Enter on an empty destination cell to move it.
+                </p>
 
                 {/* Dual pane layout */}
                 <div className="storage-grid__dual-pane">
@@ -691,10 +856,17 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
 
                 {/* Message */}
                 {message && (
-                    <div className={`storage-grid__message storage-grid__message--${message.type}`}>
+                    <div
+                        className={`storage-grid__message storage-grid__message--${message.type}`}
+                        role={message.type === 'error' ? 'alert' : 'status'}
+                    >
                         {message.text}
                     </div>
                 )}
+                <p id="storage-grid-browse-instructions" className="visually-hidden">
+                    Use Tab or the arrow keys to move between cells. Press Enter on a filled cell to
+                    open that bottle. Switch to move mode to move bottles without using drag and drop.
+                </p>
 
                 {/* Grid header with column numbers */}
                 <div className="storage-grid__header">
@@ -714,8 +886,13 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                                     key={`${rowIdx}-${colIdx}`}
                                     cell={cell}
                                     storageId={sourceStorageId!}
+                                    storageName={sourceStorage.name}
+                                    gridId={`browse-${sourceStorage.id}`}
+                                    instructionsId="storage-grid-browse-instructions"
+                                    maxColumn={sourceStorage.columns}
                                     onShowTooltip={handleShowTooltip}
                                     onHideTooltip={handleHideTooltip}
+                                    onActivate={handleBrowseCellActivate}
                                     isDragActive={activeItem !== null}
                                 />
                             ))}

--- a/wine_cellar/react/storage_grid.tsx
+++ b/wine_cellar/react/storage_grid.tsx
@@ -112,13 +112,39 @@ const getCellPositionFromElement = (element: HTMLElement): { clientX: number; cl
     };
 };
 
-const focusGridCell = (currentTarget: HTMLElement, row: number, column: number) => {
+const focusGridCell = (
+    currentTarget: HTMLElement,
+    row: number,
+    column: number,
+    rowStep = 0,
+    columnStep = 0,
+) => {
     const gridId = currentTarget.dataset.gridId;
     if (!gridId) return;
 
-    const selector = `[data-grid-id="${gridId}"][data-row="${row}"][data-column="${column}"]`;
-    const nextCell = document.querySelector<HTMLElement>(selector);
-    nextCell?.focus();
+    let nextRow = row;
+    let nextColumn = column;
+
+    while (true) {
+        const selector = `[data-grid-id="${gridId}"][data-row="${nextRow}"][data-column="${nextColumn}"]`;
+        const nextCell = document.querySelector<HTMLElement>(selector);
+
+        if (!nextCell) {
+            return;
+        }
+
+        if (!(nextCell instanceof HTMLButtonElement) || !nextCell.disabled) {
+            nextCell.focus();
+            return;
+        }
+
+        if (rowStep === 0 && columnStep === 0) {
+            return;
+        }
+
+        nextRow += rowStep;
+        nextColumn += columnStep;
+    }
 };
 
 const handleGridKeyDown = (
@@ -131,27 +157,27 @@ const handleGridKeyDown = (
     switch (event.key) {
     case 'ArrowUp':
         event.preventDefault();
-        focusGridCell(event.currentTarget, currentRow - 1, currentColumn);
+        focusGridCell(event.currentTarget, currentRow - 1, currentColumn, -1, 0);
         break;
     case 'ArrowDown':
         event.preventDefault();
-        focusGridCell(event.currentTarget, currentRow + 1, currentColumn);
+        focusGridCell(event.currentTarget, currentRow + 1, currentColumn, 1, 0);
         break;
     case 'ArrowLeft':
         event.preventDefault();
-        focusGridCell(event.currentTarget, currentRow, currentColumn - 1);
+        focusGridCell(event.currentTarget, currentRow, currentColumn - 1, 0, -1);
         break;
     case 'ArrowRight':
         event.preventDefault();
-        focusGridCell(event.currentTarget, currentRow, currentColumn + 1);
+        focusGridCell(event.currentTarget, currentRow, currentColumn + 1, 0, 1);
         break;
     case 'Home':
         event.preventDefault();
-        focusGridCell(event.currentTarget, currentRow, 1);
+        focusGridCell(event.currentTarget, currentRow, 1, 0, 1);
         break;
     case 'End':
         event.preventDefault();
-        focusGridCell(event.currentTarget, currentRow, Number(event.currentTarget.dataset.maxColumn));
+        focusGridCell(event.currentTarget, currentRow, Number(event.currentTarget.dataset.maxColumn), 0, -1);
         break;
     case 'Enter':
     case ' ':

--- a/wine_cellar/templates/base.html
+++ b/wine_cellar/templates/base.html
@@ -31,6 +31,7 @@
         </title>
     </head>
     <body class="layout">
+        <a class="skip-link" href="#main-content">Skip to main content</a>
         {% block menu %}
             {% spaceless %}
                 <header>
@@ -67,7 +68,7 @@
                 </header>
             {% endspaceless %}
         {% endblock menu %}
-        <main class="main">
+        <main class="main" id="main-content" tabindex="-1">
             {% block header %}
                 <h1 class="brand-title">{{ APP_NAME }}</h1>
             {% endblock header %}

--- a/wine_cellar/templates/core/consumption_stats.html
+++ b/wine_cellar/templates/core/consumption_stats.html
@@ -24,7 +24,17 @@
                 <div class="pure-u-1 pure-u-md-1-2">
                     <h3>By Month</h3>
                     {% if by_month %}
-                        <canvas id="chartByMonth" height="250"></canvas>
+                        <p id="consumptionChartByMonthSummary" class="visually-hidden">
+                            Consumption by month:
+                            {% for item in by_month %}
+                                {{ item.month|date:"F Y" }} {{ item.count }} consumed{% if not forloop.last %}; {% endif %}
+                            {% endfor %}
+                        </p>
+                        <canvas id="chartByMonth"
+                                height="250"
+                                role="img"
+                                aria-label="Consumption by month chart"
+                                aria-describedby="consumptionChartByMonthSummary"></canvas>
                         <details class="mt-4">
                             <summary>Show table</summary>
                             <table class="pure-table pure-table-horizontal pure-table-striped">
@@ -52,7 +62,17 @@
                 <div class="pure-u-1 pure-u-md-1-2">
                     <h3>By {{ APP_ITEM_NAME|capfirst }} Type</h3>
                     {% if by_type %}
-                        <canvas id="chartByType" height="250"></canvas>
+                        <p id="consumptionChartByTypeSummary" class="visually-hidden">
+                            Consumption by type:
+                            {% for type_name, count in by_type.items %}
+                                {{ type_name }} {{ count }} consumed{% if not forloop.last %}; {% endif %}
+                            {% endfor %}
+                        </p>
+                        <canvas id="chartByType"
+                                height="250"
+                                role="img"
+                                aria-label="Consumption by type chart"
+                                aria-describedby="consumptionChartByTypeSummary"></canvas>
                         <details class="mt-4">
                             <summary>Show table</summary>
                             <table class="pure-table pure-table-horizontal pure-table-striped">
@@ -82,7 +102,17 @@
                 <div class="pure-u-1 pure-u-md-1-2">
                     <h3>By {{ group_label }}</h3>
                     {% if by_group %}
-                        <canvas id="chartByGroup" height="250"></canvas>
+                        <p id="consumptionChartByGroupSummary" class="visually-hidden">
+                            Consumption by {{ group_label|lower }}:
+                            {% for name, count in by_group.items %}
+                                {{ name }} {{ count }} consumed{% if not forloop.last %}; {% endif %}
+                            {% endfor %}
+                        </p>
+                        <canvas id="chartByGroup"
+                                height="250"
+                                role="img"
+                                aria-label="Consumption by {{ group_label|lower }} chart"
+                                aria-describedby="consumptionChartByGroupSummary"></canvas>
                         <details class="mt-4">
                             <summary>Show table</summary>
                             <table class="pure-table pure-table-horizontal pure-table-striped">

--- a/wine_cellar/templates/core/stats_dashboard.html
+++ b/wine_cellar/templates/core/stats_dashboard.html
@@ -22,7 +22,17 @@
                 <div class="pure-u-1 pure-u-md-1-2">
                     <h3>{{ APP_ITEM_NAME|capfirst }} by Type</h3>
                     {% if by_type %}
-                        <canvas id="chartByType" height="250"></canvas>
+                        <p id="chartByTypeSummary" class="visually-hidden">
+                            {{ APP_ITEM_NAME|capfirst }} by type:
+                            {% for type_name, count in by_type.items %}
+                                {{ type_name }} {{ count }} bottle{{ count|pluralize }}{% if not forloop.last %}; {% endif %}
+                            {% endfor %}
+                        </p>
+                        <canvas id="chartByType"
+                                height="250"
+                                role="img"
+                                aria-label="{{ APP_ITEM_NAME|capfirst }} by type chart"
+                                aria-describedby="chartByTypeSummary"></canvas>
                         <details class="mt-4">
                             <summary>Show table</summary>
                             <table class="pure-table pure-table-horizontal pure-table-striped">
@@ -51,7 +61,17 @@
                 <div class="pure-u-1 pure-u-md-1-2">
                     <h3>By Country</h3>
                     {% if by_country %}
-                        <canvas id="chartByCountry" height="250"></canvas>
+                        <p id="chartByCountrySummary" class="visually-hidden">
+                            Bottles by country:
+                            {% for country_name, count in by_country.items %}
+                                {{ country_name }} {{ count }} bottle{{ count|pluralize }}{% if not forloop.last %}; {% endif %}
+                            {% endfor %}
+                        </p>
+                        <canvas id="chartByCountry"
+                                height="250"
+                                role="img"
+                                aria-label="Bottles by country chart"
+                                aria-describedby="chartByCountrySummary"></canvas>
                         <details class="mt-4">
                             <summary>Show table</summary>
                             <table class="pure-table pure-table-horizontal pure-table-striped">
@@ -82,7 +102,17 @@
                 <div class="pure-u-1 pure-u-md-1-2">
                     <h3>Purchase Trends</h3>
                     {% if by_month %}
-                        <canvas id="chartByMonth" height="250"></canvas>
+                        <p id="chartByMonthSummary" class="visually-hidden">
+                            Purchase trends by month:
+                            {% for item in by_month %}
+                                {{ item.month|date:"F Y" }} {{ item.count }} bottle{{ item.count|pluralize }} added{% if not forloop.last %}; {% endif %}
+                            {% endfor %}
+                        </p>
+                        <canvas id="chartByMonth"
+                                height="250"
+                                role="img"
+                                aria-label="Purchase trends chart"
+                                aria-describedby="chartByMonthSummary"></canvas>
                         <details class="mt-4">
                             <summary>Show table</summary>
                             <table class="pure-table pure-table-horizontal pure-table-striped">
@@ -111,7 +141,17 @@
                 <div class="pure-u-1 pure-u-md-1-2">
                     <h3>Value by Storage Location</h3>
                     {% if by_storage %}
-                        <canvas id="chartByStorage" height="250"></canvas>
+                        <p id="chartByStorageSummary" class="visually-hidden">
+                            Value by storage location:
+                            {% for name, data in by_storage.items %}
+                                {{ name }} {{ data.count }} bottle{{ data.count|pluralize }} worth {{ currency }}{{ data.value }}{% if not forloop.last %}; {% endif %}
+                            {% endfor %}
+                        </p>
+                        <canvas id="chartByStorage"
+                                height="250"
+                                role="img"
+                                aria-label="Value by storage location chart"
+                                aria-describedby="chartByStorageSummary"></canvas>
                         <details class="mt-4">
                             <summary>Show table</summary>
                             <table class="pure-table pure-table-horizontal pure-table-striped">


### PR DESCRIPTION
## Summary
- add a skip link and accessible chart summaries in shared templates
- make storage grid cells keyboard-focusable with arrow-key movement and clearer screen-reader labels
- add scanner button labels and visible focus styling for storage controls

## Testing
- /root/wine-cellar-personal/node_modules/.bin/eslint wine_cellar/react/storage_grid.tsx wine_cellar/react/react_label_scanner.tsx
- /root/wine-cellar-personal/venv/bin/py.test -q tests/test_views.py::test_base_template_includes_skip_link tests/test_views.py::test_stats_dashboard_charts_include_accessible_descriptions tests/test_scan_views.py::TestLabelScanView::test_renders_form tests/storage/test_views.py::test_storage_update_post --create-db
- CELLAR_APP_TYPE=whisky /root/wine-cellar-personal/venv/bin/py.test -q tests/whisky/test_views.py::test_whisky_stats_dashboard_renders --create-db

## Remaining work
- colour-contrast audit across themes
- automated axe-core coverage in Playwright
- wider audit of filter dropdown labels

Refs #111
