### PR TITLE
Standardize whisky URL patterns

### DIFF
--- a/tests/whisky/test_urls.py
+++ b/tests/whisky/test_urls.py
@@ -1,0 +1,54 @@
+import pytest
+from django.urls import resolve, reverse
+
+from wine_cellar.apps.whisky import views
+
+
+@pytest.mark.parametrize(
+    ("name", "args", "expected"),
+    [
+        ("whisky-edit", [1], "/whisky/edit/1/"),
+        ("whisky-delete", [1], "/whisky/delete/1/"),
+        ("whisky-scanned", ["abc123"], "/whisky/scan/abc123/"),
+        ("whisky-merge-confirm", [1, 2], "/whisky/merge/1/into/2/"),
+        ("stock-add", [1], "/stock/add/1/"),
+        ("stock-delete", [1], "/stock/delete/1/"),
+        ("stock-give", [1], "/stock/give/1/"),
+        ("bottle-edit", [1], "/bottle/edit/1/"),
+        ("drink-record-edit", [1], "/drink-history/edit/1/"),
+        ("drink-record-delete", [1], "/drink-history/delete/1/"),
+        ("wishlist-delete", [1], "/wishlist/delete/1/"),
+        ("wishlist-purchased", [1], "/wishlist/purchased/1/"),
+        ("reorder-reminder-add", [1], "/reorder/add/1/"),
+        ("reorder-reminder-delete", [1], "/reorder/delete/1/"),
+        ("bottle-note-add", [1], "/bottle/1/note/"),
+        ("bottle-history", [1], "/bottle/1/history/"),
+    ],
+)
+def test_whisky_reverse_uses_standardized_patterns(name, args, expected):
+    assert reverse(name, args=args) == expected
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_view_class"),
+    [
+        ("/whisky/1/edit/", views.WhiskyUpdateView),
+        ("/whisky/1/delete/", views.WhiskyDeleteView),
+        ("/whisky/scanned/abc123/", views.WhiskyScannedView),
+        ("/whisky/1/merge/2/", views.WhiskyMergeConfirmView),
+        ("/whisky/1/stock/add/", views.StorageItemAddView),
+        ("/stock/1/delete/", views.StorageItemDeleteView),
+        ("/stock/1/give/", views.StorageItemMarkGivenView),
+        ("/stock/1/edit/", views.StorageItemUpdateView),
+        ("/drink-record/1/edit/", views.DrinkRecordEditView),
+        ("/drink-record/1/delete/", views.DrinkRecordDeleteView),
+        ("/wishlist/1/delete/", views.WishlistDeleteView),
+        ("/wishlist/1/purchased/", views.WishlistPurchasedView),
+        ("/whisky/1/reorder/add/", views.ReorderReminderCreateView),
+        ("/reorder/1/delete/", views.ReorderReminderDeleteView),
+        ("/stock/1/note/add/", views.BottleNoteCreateView),
+        ("/stock/1/history/", views.WhiskyBottleHistoryView),
+    ],
+)
+def test_legacy_whisky_urls_still_resolve(url, expected_view_class):
+    assert resolve(url).func.view_class is expected_view_class

--- a/wine_cellar/apps/whisky/urls.py
+++ b/wine_cellar/apps/whisky/urls.py
@@ -22,16 +22,16 @@ urlpatterns = [
         name="whisky-collection-remove",
     ),
     path("whisky/<int:pk>/qr/", views.QRCodeView.as_view(), name="whisky-qr"),
-    path("whisky/<int:pk>/edit/", views.WhiskyUpdateView.as_view(), name="whisky-edit"),
+    path("whisky/edit/<int:pk>/", views.WhiskyUpdateView.as_view(), name="whisky-edit"),
     path(
-        "whisky/<int:pk>/delete/",
+        "whisky/delete/<int:pk>/",
         views.WhiskyDeleteView.as_view(),
         name="whisky-delete",
     ),
     # Scanning
     path("whisky/scan/", views.WhiskyScanView.as_view(), name="whisky-scan"),
     path(
-        "whisky/scanned/<str:code>/",
+        "whisky/scan/<str:code>/",
         views.WhiskyScannedView.as_view(),
         name="whisky-scanned",
     ),
@@ -72,29 +72,25 @@ urlpatterns = [
     ),
     # Merge
     path(
-        "whisky/<int:pk>/merge/<int:primary_pk>/",
+        "whisky/merge/<int:pk>/into/<int:primary_pk>/",
         views.WhiskyMergeConfirmView.as_view(),
         name="whisky-merge-confirm",
     ),
     # Storage/Bottles
     path("bottles/", views.StorageItemListView.as_view(), name="bottle-list"),
+    path("stock/add/<int:pk>/", views.StorageItemAddView.as_view(), name="stock-add"),
     path(
-        "whisky/<int:pk>/stock/add/",
-        views.StorageItemAddView.as_view(),
-        name="stock-add",
-    ),
-    path(
-        "stock/<int:pk>/delete/",
+        "stock/delete/<int:pk>/",
         views.StorageItemDeleteView.as_view(),
         name="stock-delete",
     ),
     path(
-        "stock/<int:pk>/give/",
+        "stock/give/<int:pk>/",
         views.StorageItemMarkGivenView.as_view(),
         name="stock-give",
     ),
     path(
-        "stock/<int:pk>/edit/",
+        "bottle/edit/<int:pk>/",
         views.StorageItemUpdateView.as_view(),
         name="bottle-edit",
     ),
@@ -112,12 +108,12 @@ urlpatterns = [
     path("drink-history/", views.DrinkRecordListView.as_view(), name="drink-history"),
     path("journey/", views.JourneyTimelineView.as_view(), name="journey-timeline"),
     path(
-        "drink-record/<int:pk>/edit/",
+        "drink-history/edit/<int:pk>/",
         views.DrinkRecordEditView.as_view(),
         name="drink-record-edit",
     ),
     path(
-        "drink-record/<int:pk>/delete/",
+        "drink-history/delete/<int:pk>/",
         views.DrinkRecordDeleteView.as_view(),
         name="drink-record-delete",
     ),
@@ -125,12 +121,12 @@ urlpatterns = [
     path("wishlist/", views.WishlistListView.as_view(), name="wishlist-list"),
     path("wishlist/add/", views.WishlistCreateView.as_view(), name="wishlist-add"),
     path(
-        "wishlist/<int:pk>/delete/",
+        "wishlist/delete/<int:pk>/",
         views.WishlistDeleteView.as_view(),
         name="wishlist-delete",
     ),
     path(
-        "wishlist/<int:pk>/purchased/",
+        "wishlist/purchased/<int:pk>/",
         views.WishlistPurchasedView.as_view(),
         name="wishlist-purchased",
     ),
@@ -146,25 +142,48 @@ urlpatterns = [
     # Reorder reminders
     path("reorder/", views.ReorderRemindersView.as_view(), name="reorder-reminders"),
     path(
-        "whisky/<int:pk>/reorder/add/",
+        "reorder/add/<int:pk>/",
         views.ReorderReminderCreateView.as_view(),
         name="reorder-reminder-add",
     ),
     path(
-        "reorder/<int:pk>/delete/",
+        "reorder/delete/<int:pk>/",
         views.ReorderReminderDeleteView.as_view(),
         name="reorder-reminder-delete",
     ),
     # Bottle notes
     path(
-        "stock/<int:pk>/note/add/",
+        "bottle/<int:pk>/note/",
         views.BottleNoteCreateView.as_view(),
         name="bottle-note-add",
     ),
     # Bottle history
     path(
-        "stock/<int:pk>/history/",
+        "bottle/<int:pk>/history/",
         views.WhiskyBottleHistoryView.as_view(),
         name="bottle-history",
     ),
+]
+
+# Keep legacy whisky URLs working for saved links and bookmarks.
+urlpatterns += [
+    path("whisky/<int:pk>/edit/", views.WhiskyUpdateView.as_view()),
+    path("whisky/<int:pk>/delete/", views.WhiskyDeleteView.as_view()),
+    path("whisky/scanned/<str:code>/", views.WhiskyScannedView.as_view()),
+    path(
+        "whisky/<int:pk>/merge/<int:primary_pk>/",
+        views.WhiskyMergeConfirmView.as_view(),
+    ),
+    path("whisky/<int:pk>/stock/add/", views.StorageItemAddView.as_view()),
+    path("stock/<int:pk>/delete/", views.StorageItemDeleteView.as_view()),
+    path("stock/<int:pk>/give/", views.StorageItemMarkGivenView.as_view()),
+    path("stock/<int:pk>/edit/", views.StorageItemUpdateView.as_view()),
+    path("drink-record/<int:pk>/edit/", views.DrinkRecordEditView.as_view()),
+    path("drink-record/<int:pk>/delete/", views.DrinkRecordDeleteView.as_view()),
+    path("wishlist/<int:pk>/delete/", views.WishlistDeleteView.as_view()),
+    path("wishlist/<int:pk>/purchased/", views.WishlistPurchasedView.as_view()),
+    path("whisky/<int:pk>/reorder/add/", views.ReorderReminderCreateView.as_view()),
+    path("reorder/<int:pk>/delete/", views.ReorderReminderDeleteView.as_view()),
+    path("stock/<int:pk>/note/add/", views.BottleNoteCreateView.as_view()),
+    path("stock/<int:pk>/history/", views.WhiskyBottleHistoryView.as_view()),
 ]


### PR DESCRIPTION
## Summary
- align whisky route shapes with the wine app for shared workflows such as edit/delete, stock actions, drink history, wishlist, reorder reminders, and bottle notes/history
- keep the previous whisky-only route shapes working as compatibility aliases for existing bookmarks and saved links
- add focused whisky URL tests to lock in both the standardized reverses and legacy path resolution

## Testing
- CELLAR_APP_TYPE=whisky /root/wine-cellar-personal/venv/bin/pytest tests/whisky/test_views.py -q --reuse-db
- CELLAR_APP_TYPE=whisky /root/wine-cellar-personal/venv/bin/pytest tests/whisky/test_urls.py tests/whisky/ -q --reuse-db
- /root/wine-cellar-personal/venv/bin/black --check wine_cellar/apps/whisky/urls.py tests/whisky/test_urls.py
- /root/wine-cellar-personal/venv/bin/isort --check-only wine_cellar/apps/whisky/urls.py tests/whisky/test_urls.py
- /root/wine-cellar-personal/venv/bin/flake8 wine_cellar/apps/whisky/urls.py tests/whisky/test_urls.py --exclude migrations,settings

Closes #93