### PR TITLE
add user-facing backup and restore

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -2,6 +2,14 @@
 
 This guide covers backup and restore procedures for Wine Cellar data.
 
+## User-Facing Account Backup
+
+Users can export and restore their current household's cellar data from **Settings**.
+
+- **Export** downloads a JSON backup of the active wine or whisky cellar, including bottles, notes, history, collections, and uploaded label images.
+- **Restore** replaces the current household's data for the active app type with a previously exported backup.
+- Backups are app-specific: wine backups restore into the wine app, and whisky backups restore into the whisky app.
+
 ## What to Back Up
 
 Wine Cellar stores data in two locations:

--- a/tests/user/test_backup.py
+++ b/tests/user/test_backup.py
@@ -1,0 +1,236 @@
+import json
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from wine_cellar.apps.storage.models import BottleMoveHistory, Storage
+from wine_cellar.apps.wine.models import (
+    BottleNote,
+    Collection,
+    DrinkingWindowAlert,
+    DrinkRecord,
+    PriceHistory,
+    ReorderReminder,
+    Wine,
+    WineImage,
+    Wishlist,
+)
+
+
+@pytest.mark.django_db
+def test_backup_export_includes_structured_wine_data(
+    client,
+    user,
+    wine_factory,
+    grape_factory,
+    attribute_factory,
+    food_pairing_factory,
+    vineyard_factory,
+    source_factory,
+    size_factory,
+    storage_factory,
+    storage_item_factory,
+    wine_image_factory,
+    clear_image_folder,
+):
+    household = user.user_settings.active_household
+    grape = grape_factory(user=user, household=household, name="Riesling")
+    attribute = attribute_factory(user=user, household=household, name="Mineral")
+    pairing = food_pairing_factory(user=user, household=household, name="Fish")
+    vineyard = vineyard_factory(user=user, household=household, name="Estate")
+    source = source_factory(user=user, household=household, name="Merchant")
+    size = size_factory(user=user, household=household)
+    wine = wine_factory(
+        user=user,
+        household=household,
+        name="Backup Riesling",
+        size=size,
+        grapes=[grape],
+    )
+    wine.attributes.add(attribute)
+    wine.food_pairings.add(pairing)
+    wine.vineyard.add(vineyard)
+    wine.source.add(source)
+    storage = storage_factory(user=user, household=household, name="Rack A")
+    destination = storage_factory(user=user, household=household, name="Rack B")
+    item = storage_item_factory(
+        user=user,
+        household=household,
+        wine=wine,
+        storage=storage,
+        row=1,
+        column=2,
+    )
+    BottleNote.objects.create(
+        user=user,
+        household=household,
+        storage_item=item,
+        note_date="2024-02-03",
+        note="Holding well",
+    )
+    DrinkRecord.objects.create(
+        user=user,
+        household=household,
+        wine=wine,
+        storage_item=item,
+        date_consumed="2024-03-04",
+        tasting_notes="Citrus",
+    )
+    DrinkingWindowAlert.objects.create(
+        user=user,
+        household=household,
+        wine=wine,
+        alert_date="2024-01-05",
+        message="Drink soon",
+    )
+    ReorderReminder.objects.create(
+        user=user,
+        household=household,
+        wine=wine,
+        min_stock=2,
+    )
+    wishlist = Wishlist.objects.create(
+        user=user,
+        household=household,
+        name="Wishlist Wine",
+    )
+    collection = Collection.objects.create(
+        user=user,
+        household=household,
+        name="Favorites",
+    )
+    collection.wines.add(wine)
+    PriceHistory.objects.create(
+        user=user,
+        household=household,
+        wine=wine,
+        source=source,
+        price="19.95",
+    )
+    BottleMoveHistory.objects.create(
+        user=user,
+        storage_item=item,
+        from_storage=storage,
+        from_row=1,
+        from_column=2,
+        to_storage=destination,
+        to_row=2,
+        to_column=1,
+    )
+    wine.barcodes.create(user=user, household=household, barcode="1234567890123")
+    wine_image_factory(wine=wine, user=user)
+
+    client.force_login(user)
+    response = client.get(reverse("user-backup-export"))
+
+    assert response.status_code == 200
+    payload = json.loads(response.content)
+    assert payload["app_type"] == "wine"
+    assert payload["data"]["wines"][0]["name"] == "Backup Riesling"
+    assert payload["data"]["wines"][0]["images"][0]["image"]["data"]
+    assert payload["data"]["collections"][0]["wines"] == [wine.pk]
+    assert payload["data"]["wishlists"][0]["name"] == wishlist.name
+    assert payload["data"]["move_history"][0]["to_storage"] == destination.pk
+
+
+@pytest.mark.django_db
+def test_backup_restore_replaces_current_wine_household_data(
+    client,
+    user,
+    wine_factory,
+    source_factory,
+    storage_factory,
+    storage_item_factory,
+    wine_image_factory,
+    clear_image_folder,
+):
+    household = user.user_settings.active_household
+    source = source_factory(user=user, household=household, name="Importer")
+    wine = wine_factory(user=user, household=household, name="Restored Wine")
+    storage = storage_factory(user=user, household=household, name="Rack A")
+    item = storage_item_factory(
+        user=user,
+        household=household,
+        wine=wine,
+        storage=storage,
+    )
+    BottleNote.objects.create(
+        user=user,
+        household=household,
+        storage_item=item,
+        note_date="2024-04-05",
+        note="From backup",
+    )
+    DrinkRecord.objects.create(
+        user=user,
+        household=household,
+        wine=wine,
+        storage_item=item,
+        date_consumed="2024-04-06",
+    )
+    PriceHistory.objects.create(
+        user=user,
+        household=household,
+        wine=wine,
+        source=source,
+        price="21.50",
+    )
+    collection = Collection.objects.create(
+        user=user,
+        household=household,
+        name="Restored Collection",
+    )
+    collection.wines.add(wine)
+    wine_image_factory(wine=wine, user=user)
+
+    client.force_login(user)
+    export_response = client.get(reverse("user-backup-export"))
+
+    replacement_storage = storage_factory(
+        user=user,
+        household=household,
+        name="Temporary Rack",
+    )
+    replacement_wine = wine_factory(
+        user=user,
+        household=household,
+        name="Temporary Wine",
+    )
+    storage_item_factory(
+        user=user,
+        household=household,
+        wine=replacement_wine,
+        storage=replacement_storage,
+    )
+
+    upload = SimpleUploadedFile(
+        "wine-backup.json",
+        export_response.content,
+        content_type="application/json",
+    )
+    response = client.post(
+        reverse("user-backup-import"),
+        {"backup_file": upload, "confirm_replace": "on"},
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Backup restored:" in response.content
+    assert list(
+        Wine.objects.filter(household=household).values_list("name", flat=True)
+    ) == ["Restored Wine"]
+    assert set(
+        Storage.objects.filter(household=household, app_type="wine").values_list(
+            "name",
+            flat=True,
+        )
+    ) == {"Default Shelf", "Rack A"}
+    assert BottleNote.objects.filter(household=household, note="From backup").exists()
+    assert DrinkRecord.objects.filter(
+        household=household, wine__name="Restored Wine"
+    ).exists()
+    assert Collection.objects.filter(
+        household=household, name="Restored Collection"
+    ).exists()
+    assert WineImage.objects.filter(wine__household=household).count() == 1

--- a/tests/whisky/test_user_backup.py
+++ b/tests/whisky/test_user_backup.py
@@ -1,0 +1,180 @@
+import base64
+import json
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from wine_cellar.apps.whisky.models import (
+    CaskHistory,
+    Collection,
+    PreviousContents,
+    WhiskyAttribute,
+    WhiskyBottleNote,
+    WhiskyDrinkRecord,
+    WhiskyImage,
+    WhiskyPriceHistory,
+    WhiskyReorderReminder,
+    WhiskySource,
+    WhiskyWishlist,
+)
+
+VALID_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMC"
+    "AO7Z0z0AAAAASUVORK5CYII="
+)
+
+
+@pytest.mark.django_db
+def test_backup_export_and_restore_for_whisky_mode(
+    client,
+    user,
+    whisky_factory,
+    distillery_factory,
+    bottler_factory,
+    whisky_region_factory,
+    storage_factory,
+    whisky_storage_item_factory,
+    clear_image_folder,
+):
+    household = user.user_settings.active_household
+    region = whisky_region_factory(name="Islay", slug="islay")
+    distillery = distillery_factory(name="Lagavulin", region=region)
+    bottler = bottler_factory(name="Indie Bottler")
+    source = WhiskySource.objects.create(user=user, household=household, name="Shop")
+    attribute = WhiskyAttribute.objects.create(
+        user=user,
+        household=household,
+        name="Smoky",
+    )
+    whisky = whisky_factory(
+        user=user,
+        household=household,
+        name="Backup Whisky",
+        region=region,
+        distillery=distillery,
+        bottler=bottler,
+        source=source,
+    )
+    whisky.attributes.add(attribute)
+    CaskHistory.objects.create(
+        whisky=whisky,
+        order=1,
+        cask_type="Bourbon Barrel",
+        previous_contents=PreviousContents.BOURBON,
+    )
+    storage = storage_factory(
+        user=user,
+        household=household,
+        app_type="whisky",
+        name="Whisky Rack",
+    )
+    item = whisky_storage_item_factory(
+        user=user,
+        household=household,
+        whisky=whisky,
+        storage=storage,
+    )
+    WhiskyBottleNote.objects.create(
+        user=user,
+        household=household,
+        storage_item=item,
+        note_date="2024-05-01",
+        note="Smoky note",
+    )
+    WhiskyDrinkRecord.objects.create(
+        user=user,
+        household=household,
+        whisky=whisky,
+        storage_item=item,
+        date_consumed="2024-05-02",
+    )
+    WhiskyPriceHistory.objects.create(
+        user=user,
+        household=household,
+        whisky=whisky,
+        source=source,
+        price="99.99",
+    )
+    WhiskyWishlist.objects.create(
+        user=user,
+        household=household,
+        name="Wishlist Whisky",
+        distillery=distillery,
+        region=region,
+    )
+    WhiskyReorderReminder.objects.create(
+        user=user,
+        household=household,
+        whisky=whisky,
+        min_stock=1,
+    )
+    collection = Collection.objects.create(
+        user=user,
+        household=household,
+        name="Peat",
+    )
+    collection.whiskies.add(whisky)
+    whisky.barcodes.create(user=user, household=household, barcode="5901234123457")
+    WhiskyImage.objects.create(
+        whisky=whisky,
+        user=user,
+        image=SimpleUploadedFile(
+            "whisky.png",
+            VALID_PNG_BYTES,
+            content_type="image/png",
+        ),
+        image_type=WhiskyImage.ImageType.LABEL_FRONT,
+        is_primary=True,
+    )
+
+    client.force_login(user)
+    export_response = client.get(reverse("user-backup-export"))
+    payload = json.loads(export_response.content)
+
+    assert export_response.status_code == 200
+    assert payload["app_type"] == "whisky"
+    assert payload["data"]["whiskies"][0]["name"] == "Backup Whisky"
+    assert (
+        payload["data"]["whiskies"][0]["cask_history"][0]["cask_type"]
+        == "Bourbon Barrel"
+    )
+    assert payload["data"]["collections"][0]["whiskies"] == [whisky.pk]
+
+    replacement = whisky_factory(
+        user=user, household=household, name="Temporary Whisky"
+    )
+    replacement.attributes.add(attribute)
+
+    upload = SimpleUploadedFile(
+        "whisky-backup.json",
+        export_response.content,
+        content_type="application/json",
+    )
+    response = client.post(
+        reverse("user-backup-import"),
+        {"backup_file": upload, "confirm_replace": "on"},
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Backup restored:" in response.content
+    assert list(
+        collection.__class__.objects.filter(household=household).values_list(
+            "name",
+            flat=True,
+        )
+    ) == ["Peat"]
+    assert list(
+        whisky.__class__.objects.filter(household=household).values_list(
+            "name", flat=True
+        )
+    ) == ["Backup Whisky"]
+    assert WhiskyBottleNote.objects.filter(
+        household=household, note="Smoky note"
+    ).exists()
+    assert WhiskyDrinkRecord.objects.filter(
+        household=household,
+        whisky__name="Backup Whisky",
+    ).exists()
+    assert WhiskyImage.objects.filter(whisky__household=household).count() == 1

--- a/wine_cellar/apps/user/backup.py
+++ b/wine_cellar/apps/user/backup.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import json
 import os
 
@@ -11,6 +12,7 @@ from django.utils import timezone
 
 BACKUP_FORMAT_VERSION = 1
 BACKUP_CONTENT_TYPE = "application/json"
+MAX_BACKUP_SIZE = 50 * 1024 * 1024  # 50MB limit
 
 USER_SETTINGS_FIELDS = [
     "currency",
@@ -241,6 +243,10 @@ def export_backup_payload(user, household) -> dict:
 def restore_backup_file(uploaded_file, *, user, household) -> dict:
     try:
         raw = uploaded_file.read()
+        if len(raw) > MAX_BACKUP_SIZE:
+            raise BackupImportError(
+                f"Backup file exceeds maximum size of {MAX_BACKUP_SIZE // (1024 * 1024)}MB."
+            )
         payload = json.loads(raw.decode("utf-8"))
     except (AttributeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise BackupImportError("Upload a valid JSON backup file.") from exc
@@ -302,9 +308,15 @@ def _restore_timestamps(instance, payload: dict, field_names: list[str]) -> None
 def _restore_file(field_file, file_payload: dict | None) -> None:
     if not file_payload or not file_payload.get("data"):
         return
-    filename = file_payload.get("name") or "backup-file"
-    content = ContentFile(base64.b64decode(file_payload["data"]))
-    field_file.save(filename, content, save=False)
+    try:
+        filename = file_payload.get("name") or "backup-file"
+        filename = os.path.basename(filename)
+        content = ContentFile(base64.b64decode(file_payload["data"]))
+        field_file.save(filename, content, save=False)
+    except (binascii.Error, ValueError) as exc:
+        raise BackupImportError(
+            f"Failed to restore file: invalid data encoding."
+        ) from exc
 
 
 def _export_file(field_file) -> dict | None:
@@ -1167,13 +1179,13 @@ def _restore_whisky_backup(data: dict, *, user, household) -> dict:
     region_map = {}
     for region_payload in refs.get("regions", []):
         region, _ = WhiskyRegion.objects.get_or_create(
-            name=region_payload["name"],
-            country=region_payload["country"],
+            slug=region_payload["slug"],
             defaults=_build_field_values(
                 WhiskyRegion,
                 region_payload,
                 [
-                    "slug",
+                    "name",
+                    "country",
                     "latitude",
                     "longitude",
                     "description",

--- a/wine_cellar/apps/user/backup.py
+++ b/wine_cellar/apps/user/backup.py
@@ -1,0 +1,1458 @@
+import base64
+import json
+import os
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import transaction
+from django.http import HttpResponse
+from django.utils import timezone
+
+BACKUP_FORMAT_VERSION = 1
+BACKUP_CONTENT_TYPE = "application/json"
+
+USER_SETTINGS_FIELDS = [
+    "currency",
+    "notifications",
+    "reminder_enabled",
+    "reminder_years_before",
+]
+HOUSEHOLD_SETTINGS_FIELDS = ["currency", "notifications"]
+STORAGE_FIELDS = [
+    "name",
+    "description",
+    "location",
+    "rows",
+    "columns",
+    "is_cold",
+    "order",
+    "is_default",
+    "cell_mask",
+    "created",
+    "modified",
+]
+WINE_REFERENCE_FIELDS = {
+    "sizes": ["name", "created", "modified"],
+    "grapes": ["name", "created", "modified"],
+    "attributes": ["name", "created", "modified"],
+    "food_pairings": ["name", "created", "modified"],
+    "vineyards": ["name", "website", "region", "country", "created", "modified"],
+    "sources": ["name", "url", "price_selector", "created", "modified"],
+}
+WINE_FIELDS = [
+    "name",
+    "wine_type",
+    "category",
+    "abv",
+    "vintage",
+    "drink_by",
+    "drink_from",
+    "drink_to",
+    "comment",
+    "rating",
+    "country",
+    "subregion",
+    "price",
+    "price_url",
+    "deleted",
+    "created",
+    "modified",
+]
+COLLECTION_FIELDS = ["name", "description", "color", "icon", "created", "modified"]
+WINE_STORAGE_ITEM_FIELDS = [
+    "row",
+    "column",
+    "deleted",
+    "price",
+    "is_gift",
+    "gift_from",
+    "occasion",
+    "rating",
+    "finished_date",
+    "recipient",
+    "given_occasion",
+    "given_date",
+    "removal_reason",
+    "created",
+    "modified",
+]
+WINE_WISHLIST_FIELDS = [
+    "name",
+    "wine_type",
+    "country",
+    "subregion",
+    "vintage",
+    "price_limit",
+    "notes",
+    "priority",
+    "purchased",
+    "created",
+    "modified",
+]
+WINE_BOTTLE_NOTE_FIELDS = ["note_date", "note", "created", "modified"]
+WINE_DRINK_RECORD_FIELDS = [
+    "date_consumed",
+    "tasting_notes",
+    "rating",
+    "shared_with",
+    "occasion",
+    "created",
+    "modified",
+]
+WINE_ALERT_FIELDS = ["alert_date", "message", "is_read", "created", "modified"]
+WINE_REMINDER_FIELDS = ["min_stock", "is_active", "created", "modified"]
+WINE_PRICE_HISTORY_FIELDS = ["price", "recorded_at", "created", "modified"]
+WHISKY_REFERENCE_FIELDS = {
+    "attributes": ["name", "created", "modified"],
+    "sources": ["name", "url", "created", "modified"],
+}
+WHISKY_FIELDS = [
+    "name",
+    "whisky_type",
+    "country",
+    "age_statement",
+    "vintage_year",
+    "bottled_year",
+    "abv",
+    "size",
+    "peated_level",
+    "cask_type",
+    "cask_strength",
+    "color",
+    "bottler_series",
+    "cask_number",
+    "batch_number",
+    "bottle_number",
+    "limited_edition",
+    "release_year",
+    "rating",
+    "price",
+    "comment",
+    "owner",
+    "deleted",
+    "created",
+    "modified",
+]
+WHISKY_CASK_HISTORY_FIELDS = [
+    "order",
+    "cask_type",
+    "wood_type",
+    "previous_contents",
+    "duration_years",
+    "is_finish",
+    "cask_number",
+    "description",
+]
+WHISKY_STORAGE_ITEM_FIELDS = [
+    "row",
+    "column",
+    "deleted",
+    "price",
+    "is_gift",
+    "gift_from",
+    "occasion",
+    "rating",
+    "fill_level",
+    "opened_date",
+    "dreg_date",
+    "owner",
+    "finished_date",
+    "recipient",
+    "given_occasion",
+    "given_date",
+    "removal_reason",
+    "created",
+    "modified",
+]
+WHISKY_WISHLIST_FIELDS = [
+    "name",
+    "whisky_type",
+    "country",
+    "age_statement",
+    "price_limit",
+    "notes",
+    "priority",
+    "purchased",
+    "created",
+    "modified",
+]
+WHISKY_BOTTLE_NOTE_FIELDS = ["note_date", "note", "created", "modified"]
+WHISKY_DRINK_RECORD_FIELDS = [
+    "date_consumed",
+    "tasting_notes",
+    "rating",
+    "shared_with",
+    "occasion",
+    "created",
+    "modified",
+]
+WHISKY_ALERT_FIELDS = ["alert_date", "message", "is_read", "created", "modified"]
+WHISKY_REMINDER_FIELDS = ["min_stock", "is_active", "created", "modified"]
+WHISKY_PRICE_HISTORY_FIELDS = ["price", "recorded_at", "created", "modified"]
+MOVE_HISTORY_FIELDS = [
+    "from_row",
+    "from_column",
+    "to_row",
+    "to_column",
+    "moved_at",
+]
+
+
+class BackupImportError(Exception):
+    pass
+
+
+def build_backup_response(user, household) -> HttpResponse:
+    payload = export_backup_payload(user, household)
+    app_type = payload["app_type"]
+    today = timezone.localdate().isoformat()
+    response = HttpResponse(
+        json.dumps(payload, indent=2, cls=DjangoJSONEncoder, ensure_ascii=False),
+        content_type=BACKUP_CONTENT_TYPE,
+    )
+    response["Content-Disposition"] = (
+        f'attachment; filename="{app_type}_backup_{today}.json"'
+    )
+    return response
+
+
+def export_backup_payload(user, household) -> dict:
+    payload = {
+        "format_version": BACKUP_FORMAT_VERSION,
+        "app_type": _get_app_type(),
+        "exported_at": timezone.now(),
+        "household": {"name": household.name},
+        "user_settings": _export_simple_fields(
+            user.user_settings, USER_SETTINGS_FIELDS
+        ),
+        "household_settings": _export_simple_fields(
+            household.settings if hasattr(household, "settings") else None,
+            HOUSEHOLD_SETTINGS_FIELDS,
+        ),
+    }
+    if payload["app_type"] == "whisky":
+        payload["data"] = _export_whisky_backup(user, household)
+    else:
+        payload["data"] = _export_wine_backup(user, household)
+    return payload
+
+
+def restore_backup_file(uploaded_file, *, user, household) -> dict:
+    try:
+        raw = uploaded_file.read()
+        payload = json.loads(raw.decode("utf-8"))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BackupImportError("Upload a valid JSON backup file.") from exc
+    return restore_backup_payload(payload, user=user, household=household)
+
+
+def restore_backup_payload(payload: dict, *, user, household) -> dict:
+    if not isinstance(payload, dict):
+        raise BackupImportError("Backup file must contain a JSON object.")
+    if payload.get("format_version") != BACKUP_FORMAT_VERSION:
+        raise BackupImportError("Unsupported backup format.")
+    app_type = payload.get("app_type")
+    if app_type != _get_app_type():
+        raise BackupImportError("This backup was created for a different app type.")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise BackupImportError("Backup file is missing its data section.")
+
+    with transaction.atomic():
+        _restore_settings(payload, user=user, household=household)
+        if app_type == "whisky":
+            return _restore_whisky_backup(data, user=user, household=household)
+        return _restore_wine_backup(data, user=user, household=household)
+
+
+def _get_app_type() -> str:
+    return getattr(settings, "CELLAR_APP_TYPE", "wine")
+
+
+def _export_simple_fields(instance, fields: list[str]) -> dict:
+    if instance is None:
+        return {}
+    return {field: getattr(instance, field) for field in fields}
+
+
+def _build_field_values(model_class, payload: dict, fields: list[str]) -> dict:
+    values = {}
+    for field_name in fields:
+        if field_name not in payload:
+            continue
+        field = model_class._meta.get_field(field_name)
+        values[field_name] = field.to_python(payload[field_name])
+    return values
+
+
+def _restore_timestamps(instance, payload: dict, field_names: list[str]) -> None:
+    updates = {}
+    for field_name in field_names:
+        if payload.get(field_name) in (None, ""):
+            continue
+        field = instance._meta.get_field(field_name)
+        updates[field_name] = field.to_python(payload[field_name])
+    if updates:
+        instance.__class__.objects.filter(pk=instance.pk).update(**updates)
+        for field_name, value in updates.items():
+            setattr(instance, field_name, value)
+
+
+def _restore_file(field_file, file_payload: dict | None) -> None:
+    if not file_payload or not file_payload.get("data"):
+        return
+    filename = file_payload.get("name") or "backup-file"
+    content = ContentFile(base64.b64decode(file_payload["data"]))
+    field_file.save(filename, content, save=False)
+
+
+def _export_file(field_file) -> dict | None:
+    if not field_file:
+        return None
+    try:
+        with field_file.open("rb") as uploaded:
+            content = uploaded.read()
+    except FileNotFoundError:
+        return None
+    return {
+        "name": os.path.basename(field_file.name),
+        "data": base64.b64encode(content).decode("ascii"),
+    }
+
+
+def _require_mapping(mapping: dict, backup_id, label: str):
+    if backup_id in (None, ""):
+        return None
+    value = mapping.get(backup_id)
+    if value is None:
+        raise BackupImportError(
+            f"Backup file contains an unknown {label} reference: {backup_id}."
+        )
+    return value
+
+
+def _require_many(mapping: dict, backup_ids: list, label: str) -> list:
+    return [_require_mapping(mapping, backup_id, label) for backup_id in backup_ids]
+
+
+def _export_reference_items(queryset, fields: list[str]) -> list[dict]:
+    return [
+        {"backup_id": obj.pk, **_export_simple_fields(obj, fields)}
+        for obj in queryset.order_by("pk")
+    ]
+
+
+def _export_move_histories(queryset) -> list[dict]:
+    return [
+        {
+            "storage_item": history.storage_item_id,
+            "from_storage": history.from_storage_id,
+            "to_storage": history.to_storage_id,
+            **_export_simple_fields(history, MOVE_HISTORY_FIELDS),
+        }
+        for history in queryset.order_by("pk")
+    ]
+
+
+def _export_wine_backup(user, household) -> dict:
+    from wine_cellar.apps.storage.models import BottleMoveHistory, Storage, StorageItem
+    from wine_cellar.apps.wine.models import (
+        Appellation,
+        Attribute,
+        BottleNote,
+        Collection,
+        DrinkingWindowAlert,
+        DrinkRecord,
+        FoodPairing,
+        Grape,
+        PriceHistory,
+        ReorderReminder,
+        Size,
+        Source,
+        Vineyard,
+        Wine,
+        Wishlist,
+    )
+
+    storages = Storage.objects.filter(household=household, app_type="wine").order_by(
+        "pk"
+    )
+    wines = Wine.objects.filter(household=household).prefetch_related(
+        "grapes",
+        "attributes",
+        "food_pairings",
+        "vineyard",
+        "source",
+        "wineimage_set",
+        "barcodes",
+    )
+    collections = Collection.objects.filter(household=household).prefetch_related(
+        "wines"
+    )
+    storage_items = StorageItem.objects.filter(household=household).select_related(
+        "wine",
+        "storage",
+    )
+
+    return {
+        "storages": [
+            {"backup_id": storage.pk, **_export_simple_fields(storage, STORAGE_FIELDS)}
+            for storage in storages
+        ],
+        "references": {
+            "sizes": _export_reference_items(
+                Size.objects.filter(household=household), WINE_REFERENCE_FIELDS["sizes"]
+            ),
+            "grapes": _export_reference_items(
+                Grape.objects.filter(household=household),
+                WINE_REFERENCE_FIELDS["grapes"],
+            ),
+            "attributes": _export_reference_items(
+                Attribute.objects.filter(household=household),
+                WINE_REFERENCE_FIELDS["attributes"],
+            ),
+            "food_pairings": _export_reference_items(
+                FoodPairing.objects.filter(household=household),
+                WINE_REFERENCE_FIELDS["food_pairings"],
+            ),
+            "vineyards": _export_reference_items(
+                Vineyard.objects.filter(household=household),
+                WINE_REFERENCE_FIELDS["vineyards"],
+            ),
+            "sources": _export_reference_items(
+                Source.objects.filter(household=household),
+                WINE_REFERENCE_FIELDS["sources"],
+            ),
+        },
+        "wines": [
+            {
+                "backup_id": wine.pk,
+                **_export_simple_fields(wine, WINE_FIELDS),
+                "size": wine.size_id,
+                "appellation": (
+                    {
+                        "name": wine.appellation.name,
+                        "country": wine.appellation.country,
+                        "latitude": wine.appellation.latitude,
+                        "longitude": wine.appellation.longitude,
+                    }
+                    if isinstance(wine.appellation, Appellation)
+                    else None
+                ),
+                "grapes": list(wine.grapes.values_list("pk", flat=True)),
+                "attributes": list(wine.attributes.values_list("pk", flat=True)),
+                "food_pairings": list(wine.food_pairings.values_list("pk", flat=True)),
+                "vineyard": list(wine.vineyard.values_list("pk", flat=True)),
+                "source": list(wine.source.values_list("pk", flat=True)),
+                "barcodes": [
+                    {"barcode": barcode.barcode, "created": barcode.created}
+                    for barcode in wine.barcodes.all().order_by("pk")
+                ],
+                "images": [
+                    {
+                        "image_type": image.image_type,
+                        "is_primary": image.is_primary,
+                        "image": _export_file(image.image),
+                        "thumbnail": _export_file(image.thumbnail),
+                    }
+                    for image in wine.wineimage_set.all().order_by("pk")
+                ],
+            }
+            for wine in wines.order_by("pk")
+        ],
+        "collections": [
+            {
+                "backup_id": collection.pk,
+                **_export_simple_fields(collection, COLLECTION_FIELDS),
+                "wines": list(collection.wines.values_list("pk", flat=True)),
+            }
+            for collection in collections.order_by("pk")
+        ],
+        "storage_items": [
+            {
+                "backup_id": item.pk,
+                "storage": item.storage_id,
+                "wine": item.wine_id,
+                **_export_simple_fields(item, WINE_STORAGE_ITEM_FIELDS),
+            }
+            for item in storage_items.order_by("pk")
+        ],
+        "wishlists": [
+            {"backup_id": item.pk, **_export_simple_fields(item, WINE_WISHLIST_FIELDS)}
+            for item in Wishlist.objects.filter(household=household).order_by("pk")
+        ],
+        "bottle_notes": [
+            {
+                "backup_id": note.pk,
+                "storage_item": note.storage_item_id,
+                **_export_simple_fields(note, WINE_BOTTLE_NOTE_FIELDS),
+            }
+            for note in BottleNote.objects.filter(household=household).order_by("pk")
+        ],
+        "drink_records": [
+            {
+                "backup_id": record.pk,
+                "wine": record.wine_id,
+                "storage_item": record.storage_item_id,
+                **_export_simple_fields(record, WINE_DRINK_RECORD_FIELDS),
+            }
+            for record in DrinkRecord.objects.filter(household=household).order_by("pk")
+        ],
+        "alerts": [
+            {
+                "backup_id": alert.pk,
+                "wine": alert.wine_id,
+                **_export_simple_fields(alert, WINE_ALERT_FIELDS),
+            }
+            for alert in DrinkingWindowAlert.objects.filter(
+                household=household
+            ).order_by("pk")
+        ],
+        "reorder_reminders": [
+            {
+                "backup_id": reminder.pk,
+                "wine": reminder.wine_id,
+                **_export_simple_fields(reminder, WINE_REMINDER_FIELDS),
+            }
+            for reminder in ReorderReminder.objects.filter(
+                household=household
+            ).order_by("pk")
+        ],
+        "price_history": [
+            {
+                "backup_id": record.pk,
+                "wine": record.wine_id,
+                "source": record.source_id,
+                **_export_simple_fields(record, WINE_PRICE_HISTORY_FIELDS),
+            }
+            for record in PriceHistory.objects.filter(household=household).order_by(
+                "pk"
+            )
+        ],
+        "move_history": _export_move_histories(
+            BottleMoveHistory.objects.filter(
+                storage_item__household=household
+            ).select_related(
+                "storage_item",
+                "from_storage",
+                "to_storage",
+            )
+        ),
+    }
+
+
+def _export_whisky_backup(user, household) -> dict:
+    from wine_cellar.apps.storage.models import Storage
+    from wine_cellar.apps.whisky.models import (
+        Bottler,
+        Collection,
+        Distillery,
+        Whisky,
+        WhiskyAttribute,
+        WhiskyBottleMoveHistory,
+        WhiskyBottleNote,
+        WhiskyDrinkingWindowAlert,
+        WhiskyDrinkRecord,
+        WhiskyPriceHistory,
+        WhiskyRegion,
+        WhiskyReorderReminder,
+        WhiskySource,
+        WhiskyStorageItem,
+        WhiskyWishlist,
+    )
+
+    whiskies = Whisky.objects.filter(household=household).prefetch_related(
+        "attributes",
+        "images",
+        "barcodes",
+        "cask_history",
+    )
+
+    regions = {
+        region.pk: region
+        for region in WhiskyRegion.objects.filter(
+            pk__in=filter(None, whiskies.values_list("region_id", flat=True))
+        )
+    }
+    distilleries = {
+        distillery.pk: distillery
+        for distillery in Distillery.objects.filter(
+            pk__in=filter(None, whiskies.values_list("distillery_id", flat=True))
+        )
+    }
+    bottlers = {
+        bottler.pk: bottler
+        for bottler in Bottler.objects.filter(
+            pk__in=filter(None, whiskies.values_list("bottler_id", flat=True))
+        )
+    }
+    for wishlist in WhiskyWishlist.objects.filter(household=household):
+        if wishlist.region_id:
+            regions[wishlist.region_id] = wishlist.region
+        if wishlist.distillery_id:
+            distilleries[wishlist.distillery_id] = wishlist.distillery
+
+    return {
+        "storages": [
+            {"backup_id": storage.pk, **_export_simple_fields(storage, STORAGE_FIELDS)}
+            for storage in Storage.objects.filter(
+                household=household,
+                app_type="whisky",
+            ).order_by("pk")
+        ],
+        "references": {
+            "attributes": _export_reference_items(
+                WhiskyAttribute.objects.filter(household=household),
+                WHISKY_REFERENCE_FIELDS["attributes"],
+            ),
+            "sources": _export_reference_items(
+                WhiskySource.objects.filter(household=household),
+                WHISKY_REFERENCE_FIELDS["sources"],
+            ),
+            "regions": [
+                {
+                    "backup_id": region.pk,
+                    **_export_simple_fields(
+                        region,
+                        [
+                            "name",
+                            "slug",
+                            "country",
+                            "latitude",
+                            "longitude",
+                            "description",
+                            "order",
+                        ],
+                    ),
+                }
+                for region in sorted(regions.values(), key=lambda region: region.pk)
+            ],
+            "distilleries": [
+                {
+                    "backup_id": distillery.pk,
+                    **_export_simple_fields(
+                        distillery,
+                        [
+                            "name",
+                            "country",
+                            "latitude",
+                            "longitude",
+                            "status",
+                            "founded_year",
+                            "closed_year",
+                            "owner",
+                            "description",
+                            "is_user_created",
+                        ],
+                    ),
+                    "region": distillery.region_id,
+                }
+                for distillery in sorted(
+                    distilleries.values(),
+                    key=lambda distillery: distillery.pk,
+                )
+            ],
+            "bottlers": [
+                {
+                    "backup_id": bottler.pk,
+                    **_export_simple_fields(
+                        bottler,
+                        [
+                            "name",
+                            "short_name",
+                            "country",
+                            "website",
+                            "description",
+                            "is_user_created",
+                        ],
+                    ),
+                }
+                for bottler in sorted(bottlers.values(), key=lambda bottler: bottler.pk)
+            ],
+        },
+        "whiskies": [
+            {
+                "backup_id": whisky.pk,
+                **_export_simple_fields(whisky, WHISKY_FIELDS),
+                "region": whisky.region_id,
+                "distillery": whisky.distillery_id,
+                "bottler": whisky.bottler_id,
+                "source": whisky.source_id,
+                "attributes": list(whisky.attributes.values_list("pk", flat=True)),
+                "barcodes": [
+                    {"barcode": barcode.barcode, "created": barcode.created}
+                    for barcode in whisky.barcodes.all().order_by("pk")
+                ],
+                "images": [
+                    {
+                        "image_type": image.image_type,
+                        "is_primary": image.is_primary,
+                        "created": image.created,
+                        "image": _export_file(image.image),
+                        "thumbnail": _export_file(image.thumbnail),
+                    }
+                    for image in whisky.images.all().order_by("pk")
+                ],
+                "cask_history": [
+                    {
+                        "backup_id": history.pk,
+                        **_export_simple_fields(history, WHISKY_CASK_HISTORY_FIELDS),
+                    }
+                    for history in whisky.cask_history.all().order_by("pk")
+                ],
+            }
+            for whisky in whiskies.order_by("pk")
+        ],
+        "collections": [
+            {
+                "backup_id": collection.pk,
+                **_export_simple_fields(collection, COLLECTION_FIELDS),
+                "whiskies": list(collection.whiskies.values_list("pk", flat=True)),
+            }
+            for collection in Collection.objects.filter(household=household)
+            .prefetch_related("whiskies")
+            .order_by("pk")
+        ],
+        "storage_items": [
+            {
+                "backup_id": item.pk,
+                "storage": item.storage_id,
+                "whisky": item.whisky_id,
+                **_export_simple_fields(item, WHISKY_STORAGE_ITEM_FIELDS),
+            }
+            for item in WhiskyStorageItem.objects.filter(household=household)
+            .select_related("storage", "whisky")
+            .order_by("pk")
+        ],
+        "wishlists": [
+            {
+                "backup_id": item.pk,
+                "distillery": item.distillery_id,
+                "region": item.region_id,
+                **_export_simple_fields(item, WHISKY_WISHLIST_FIELDS),
+            }
+            for item in WhiskyWishlist.objects.filter(household=household).order_by(
+                "pk"
+            )
+        ],
+        "bottle_notes": [
+            {
+                "backup_id": note.pk,
+                "storage_item": note.storage_item_id,
+                **_export_simple_fields(note, WHISKY_BOTTLE_NOTE_FIELDS),
+            }
+            for note in WhiskyBottleNote.objects.filter(household=household).order_by(
+                "pk"
+            )
+        ],
+        "drink_records": [
+            {
+                "backup_id": record.pk,
+                "whisky": record.whisky_id,
+                "storage_item": record.storage_item_id,
+                **_export_simple_fields(record, WHISKY_DRINK_RECORD_FIELDS),
+            }
+            for record in WhiskyDrinkRecord.objects.filter(
+                household=household
+            ).order_by("pk")
+        ],
+        "alerts": [
+            {
+                "backup_id": alert.pk,
+                "whisky": alert.whisky_id,
+                **_export_simple_fields(alert, WHISKY_ALERT_FIELDS),
+            }
+            for alert in WhiskyDrinkingWindowAlert.objects.filter(
+                household=household
+            ).order_by("pk")
+        ],
+        "reorder_reminders": [
+            {
+                "backup_id": reminder.pk,
+                "whisky": reminder.whisky_id,
+                **_export_simple_fields(reminder, WHISKY_REMINDER_FIELDS),
+            }
+            for reminder in WhiskyReorderReminder.objects.filter(
+                household=household
+            ).order_by("pk")
+        ],
+        "price_history": [
+            {
+                "backup_id": record.pk,
+                "whisky": record.whisky_id,
+                "source": record.source_id,
+                **_export_simple_fields(record, WHISKY_PRICE_HISTORY_FIELDS),
+            }
+            for record in WhiskyPriceHistory.objects.filter(
+                household=household
+            ).order_by("pk")
+        ],
+        "move_history": _export_move_histories(
+            WhiskyBottleMoveHistory.objects.filter(
+                storage_item__household=household
+            ).select_related("storage_item", "from_storage", "to_storage")
+        ),
+    }
+
+
+def _restore_settings(payload: dict, *, user, household) -> None:
+    from wine_cellar.apps.household.models import HouseholdSettings
+    from wine_cellar.apps.user.models import UserSettings
+
+    user_settings, _ = UserSettings.objects.get_or_create(user=user)
+    for field_name, value in _build_field_values(
+        UserSettings,
+        payload.get("user_settings") or {},
+        USER_SETTINGS_FIELDS,
+    ).items():
+        setattr(user_settings, field_name, value)
+    user_settings.active_household = household
+    user_settings.save()
+
+    household_settings, _ = HouseholdSettings.objects.get_or_create(household=household)
+    for field_name, value in _build_field_values(
+        HouseholdSettings,
+        payload.get("household_settings") or {},
+        HOUSEHOLD_SETTINGS_FIELDS,
+    ).items():
+        setattr(household_settings, field_name, value)
+    household_settings.save()
+
+    household_name = (payload.get("household") or {}).get("name")
+    if household_name:
+        household.name = household_name
+        household.save(update_fields=["name"])
+
+
+def _restore_wine_backup(data: dict, *, user, household) -> dict:
+    from wine_cellar.apps.storage.models import BottleMoveHistory, Storage, StorageItem
+    from wine_cellar.apps.wine.models import (
+        Appellation,
+        Attribute,
+        BottleNote,
+        Collection,
+        DrinkingWindowAlert,
+        DrinkRecord,
+        FoodPairing,
+        Grape,
+        PriceHistory,
+        ReorderReminder,
+        Size,
+        Source,
+        Vineyard,
+        Wine,
+        WineBarcode,
+        WineImage,
+        Wishlist,
+    )
+
+    Collection.objects.filter(household=household).delete()
+    Wishlist.objects.filter(household=household).delete()
+    Wine.objects.filter(household=household).delete()
+    Storage.objects.filter(household=household, app_type="wine").delete()
+    Size.objects.filter(household=household).delete()
+    Grape.objects.filter(household=household).delete()
+    Attribute.objects.filter(household=household).delete()
+    FoodPairing.objects.filter(household=household).delete()
+    Vineyard.objects.filter(household=household).delete()
+    Source.objects.filter(household=household).delete()
+
+    storage_map = {}
+    for storage_payload in data.get("storages", []):
+        storage = Storage.objects.create(
+            user=user,
+            household=household,
+            app_type="wine",
+            **_build_field_values(Storage, storage_payload, STORAGE_FIELDS),
+        )
+        _restore_timestamps(storage, storage_payload, ["created", "modified"])
+        storage_map[storage_payload["backup_id"]] = storage
+
+    refs = data.get("references", {})
+    size_map = _restore_reference_items(
+        items=refs.get("sizes", []),
+        model_class=Size,
+        user=user,
+        household=household,
+        fields=WINE_REFERENCE_FIELDS["sizes"],
+    )
+    grape_map = _restore_reference_items(
+        items=refs.get("grapes", []),
+        model_class=Grape,
+        user=user,
+        household=household,
+        fields=WINE_REFERENCE_FIELDS["grapes"],
+    )
+    attribute_map = _restore_reference_items(
+        items=refs.get("attributes", []),
+        model_class=Attribute,
+        user=user,
+        household=household,
+        fields=WINE_REFERENCE_FIELDS["attributes"],
+    )
+    pairing_map = _restore_reference_items(
+        items=refs.get("food_pairings", []),
+        model_class=FoodPairing,
+        user=user,
+        household=household,
+        fields=WINE_REFERENCE_FIELDS["food_pairings"],
+    )
+    vineyard_map = _restore_reference_items(
+        items=refs.get("vineyards", []),
+        model_class=Vineyard,
+        user=user,
+        household=household,
+        fields=WINE_REFERENCE_FIELDS["vineyards"],
+    )
+    source_map = _restore_reference_items(
+        items=refs.get("sources", []),
+        model_class=Source,
+        user=user,
+        household=household,
+        fields=WINE_REFERENCE_FIELDS["sources"],
+    )
+
+    wine_map = {}
+    for wine_payload in data.get("wines", []):
+        appellation_payload = wine_payload.get("appellation")
+        appellation = None
+        if appellation_payload:
+            appellation, _ = Appellation.objects.get_or_create(
+                name=appellation_payload["name"],
+                country=appellation_payload["country"],
+                defaults={
+                    "latitude": appellation_payload.get("latitude") or 0,
+                    "longitude": appellation_payload.get("longitude") or 0,
+                },
+            )
+
+        wine = Wine.objects.create(
+            user=user,
+            household=household,
+            size=_require_mapping(size_map, wine_payload.get("size"), "size"),
+            appellation=appellation,
+            **_build_field_values(Wine, wine_payload, WINE_FIELDS),
+        )
+        wine.grapes.set(
+            _require_many(grape_map, wine_payload.get("grapes", []), "grape")
+        )
+        wine.attributes.set(
+            _require_many(
+                attribute_map, wine_payload.get("attributes", []), "attribute"
+            )
+        )
+        wine.food_pairings.set(
+            _require_many(
+                pairing_map,
+                wine_payload.get("food_pairings", []),
+                "food pairing",
+            )
+        )
+        wine.vineyard.set(
+            _require_many(vineyard_map, wine_payload.get("vineyard", []), "vineyard")
+        )
+        wine.source.set(
+            _require_many(source_map, wine_payload.get("source", []), "source")
+        )
+        _restore_timestamps(wine, wine_payload, ["created", "modified"])
+        wine_map[wine_payload["backup_id"]] = wine
+
+        for barcode_payload in wine_payload.get("barcodes", []):
+            barcode = WineBarcode.objects.create(
+                wine=wine,
+                user=user,
+                household=household,
+                barcode=barcode_payload["barcode"],
+            )
+            _restore_timestamps(barcode, barcode_payload, ["created"])
+
+        for image_payload in wine_payload.get("images", []):
+            image = WineImage(
+                wine=wine,
+                user=user,
+                image_type=image_payload["image_type"],
+                is_primary=image_payload["is_primary"],
+            )
+            _restore_file(image.image, image_payload.get("image"))
+            _restore_file(image.thumbnail, image_payload.get("thumbnail"))
+            image.save()
+
+    for collection_payload in data.get("collections", []):
+        collection = Collection.objects.create(
+            user=user,
+            household=household,
+            **_build_field_values(Collection, collection_payload, COLLECTION_FIELDS),
+        )
+        collection.wines.set(
+            _require_many(wine_map, collection_payload.get("wines", []), "wine")
+        )
+        _restore_timestamps(collection, collection_payload, ["created", "modified"])
+
+    storage_item_map = {}
+    for item_payload in data.get("storage_items", []):
+        item = StorageItem.objects.create(
+            user=user,
+            household=household,
+            storage=_require_mapping(storage_map, item_payload["storage"], "storage"),
+            wine=_require_mapping(wine_map, item_payload["wine"], "wine"),
+            **_build_field_values(StorageItem, item_payload, WINE_STORAGE_ITEM_FIELDS),
+        )
+        _restore_timestamps(item, item_payload, ["created", "modified"])
+        storage_item_map[item_payload["backup_id"]] = item
+
+    for wishlist_payload in data.get("wishlists", []):
+        wishlist = Wishlist.objects.create(
+            user=user,
+            household=household,
+            **_build_field_values(Wishlist, wishlist_payload, WINE_WISHLIST_FIELDS),
+        )
+        _restore_timestamps(wishlist, wishlist_payload, ["created", "modified"])
+
+    for note_payload in data.get("bottle_notes", []):
+        note = BottleNote.objects.create(
+            user=user,
+            household=household,
+            storage_item=_require_mapping(
+                storage_item_map,
+                note_payload["storage_item"],
+                "storage item",
+            ),
+            **_build_field_values(BottleNote, note_payload, WINE_BOTTLE_NOTE_FIELDS),
+        )
+        _restore_timestamps(note, note_payload, ["created", "modified"])
+
+    for record_payload in data.get("drink_records", []):
+        record = DrinkRecord.objects.create(
+            user=user,
+            household=household,
+            wine=_require_mapping(wine_map, record_payload["wine"], "wine"),
+            storage_item=_require_mapping(
+                storage_item_map,
+                record_payload.get("storage_item"),
+                "storage item",
+            ),
+            **_build_field_values(
+                DrinkRecord,
+                record_payload,
+                WINE_DRINK_RECORD_FIELDS,
+            ),
+        )
+        _restore_timestamps(record, record_payload, ["created", "modified"])
+
+    for alert_payload in data.get("alerts", []):
+        alert = DrinkingWindowAlert.objects.create(
+            user=user,
+            household=household,
+            wine=_require_mapping(wine_map, alert_payload["wine"], "wine"),
+            **_build_field_values(
+                DrinkingWindowAlert,
+                alert_payload,
+                WINE_ALERT_FIELDS,
+            ),
+        )
+        _restore_timestamps(alert, alert_payload, ["created", "modified"])
+
+    for reminder_payload in data.get("reorder_reminders", []):
+        reminder = ReorderReminder.objects.create(
+            user=user,
+            household=household,
+            wine=_require_mapping(wine_map, reminder_payload["wine"], "wine"),
+            **_build_field_values(
+                ReorderReminder,
+                reminder_payload,
+                WINE_REMINDER_FIELDS,
+            ),
+        )
+        _restore_timestamps(reminder, reminder_payload, ["created", "modified"])
+
+    for price_payload in data.get("price_history", []):
+        record = PriceHistory.objects.create(
+            user=user,
+            household=household,
+            wine=_require_mapping(wine_map, price_payload["wine"], "wine"),
+            source=_require_mapping(source_map, price_payload.get("source"), "source"),
+            **_build_field_values(PriceHistory, price_payload, ["price"]),
+        )
+        _restore_timestamps(record, price_payload, ["recorded_at"])
+
+    for history_payload in data.get("move_history", []):
+        history = BottleMoveHistory.objects.create(
+            user=user,
+            storage_item=_require_mapping(
+                storage_item_map,
+                history_payload["storage_item"],
+                "storage item",
+            ),
+            from_storage=_require_mapping(
+                storage_map,
+                history_payload.get("from_storage"),
+                "storage",
+            ),
+            to_storage=_require_mapping(
+                storage_map,
+                history_payload.get("to_storage"),
+                "storage",
+            ),
+            **_build_field_values(
+                BottleMoveHistory, history_payload, MOVE_HISTORY_FIELDS
+            ),
+        )
+        _restore_timestamps(history, history_payload, ["moved_at"])
+
+    return {
+        "app_type": "wine",
+        "beverages": len(wine_map),
+        "storages": len(storage_map),
+        "bottles": len(storage_item_map),
+    }
+
+
+def _restore_whisky_backup(data: dict, *, user, household) -> dict:
+    from wine_cellar.apps.storage.models import Storage
+    from wine_cellar.apps.whisky.models import (
+        Bottler,
+        CaskHistory,
+        Collection,
+        Distillery,
+        Whisky,
+        WhiskyAttribute,
+        WhiskyBarcode,
+        WhiskyBottleMoveHistory,
+        WhiskyBottleNote,
+        WhiskyDrinkingWindowAlert,
+        WhiskyDrinkRecord,
+        WhiskyImage,
+        WhiskyPriceHistory,
+        WhiskyRegion,
+        WhiskyReorderReminder,
+        WhiskySource,
+        WhiskyStorageItem,
+        WhiskyWishlist,
+    )
+
+    Collection.objects.filter(household=household).delete()
+    WhiskyWishlist.objects.filter(household=household).delete()
+    Whisky.objects.filter(household=household).delete()
+    Storage.objects.filter(household=household, app_type="whisky").delete()
+    WhiskyAttribute.objects.filter(household=household).delete()
+    WhiskySource.objects.filter(household=household).delete()
+
+    storage_map = {}
+    for storage_payload in data.get("storages", []):
+        storage = Storage.objects.create(
+            user=user,
+            household=household,
+            app_type="whisky",
+            **_build_field_values(Storage, storage_payload, STORAGE_FIELDS),
+        )
+        _restore_timestamps(storage, storage_payload, ["created", "modified"])
+        storage_map[storage_payload["backup_id"]] = storage
+
+    refs = data.get("references", {})
+    attribute_map = _restore_reference_items(
+        items=refs.get("attributes", []),
+        model_class=WhiskyAttribute,
+        user=user,
+        household=household,
+        fields=WHISKY_REFERENCE_FIELDS["attributes"],
+    )
+    source_map = _restore_reference_items(
+        items=refs.get("sources", []),
+        model_class=WhiskySource,
+        user=user,
+        household=household,
+        fields=WHISKY_REFERENCE_FIELDS["sources"],
+    )
+    region_map = {}
+    for region_payload in refs.get("regions", []):
+        region, _ = WhiskyRegion.objects.get_or_create(
+            name=region_payload["name"],
+            country=region_payload["country"],
+            defaults=_build_field_values(
+                WhiskyRegion,
+                region_payload,
+                [
+                    "slug",
+                    "latitude",
+                    "longitude",
+                    "description",
+                    "order",
+                ],
+            ),
+        )
+        region_map[region_payload["backup_id"]] = region
+
+    distillery_map = {}
+    for distillery_payload in refs.get("distilleries", []):
+        distillery, _ = Distillery.objects.get_or_create(
+            name=distillery_payload["name"],
+            country=distillery_payload["country"],
+            defaults={
+                **_build_field_values(
+                    Distillery,
+                    distillery_payload,
+                    [
+                        "latitude",
+                        "longitude",
+                        "status",
+                        "founded_year",
+                        "closed_year",
+                        "owner",
+                        "description",
+                        "is_user_created",
+                    ],
+                ),
+                "region": region_map.get(distillery_payload.get("region")),
+            },
+        )
+        if distillery.region_id is None and distillery_payload.get("region"):
+            distillery.region = region_map.get(distillery_payload.get("region"))
+            distillery.save(update_fields=["region"])
+        distillery_map[distillery_payload["backup_id"]] = distillery
+
+    bottler_map = {}
+    for bottler_payload in refs.get("bottlers", []):
+        bottler, _ = Bottler.objects.get_or_create(
+            name=bottler_payload["name"],
+            country=bottler_payload["country"],
+            defaults=_build_field_values(
+                Bottler,
+                bottler_payload,
+                [
+                    "short_name",
+                    "website",
+                    "description",
+                    "is_user_created",
+                ],
+            ),
+        )
+        bottler_map[bottler_payload["backup_id"]] = bottler
+
+    whisky_map = {}
+    for whisky_payload in data.get("whiskies", []):
+        whisky = Whisky.objects.create(
+            user=user,
+            household=household,
+            region=_require_mapping(region_map, whisky_payload.get("region"), "region"),
+            distillery=_require_mapping(
+                distillery_map,
+                whisky_payload.get("distillery"),
+                "distillery",
+            ),
+            bottler=_require_mapping(
+                bottler_map,
+                whisky_payload.get("bottler"),
+                "bottler",
+            ),
+            source=_require_mapping(source_map, whisky_payload.get("source"), "source"),
+            **_build_field_values(Whisky, whisky_payload, WHISKY_FIELDS),
+        )
+        whisky.attributes.set(
+            _require_many(
+                attribute_map,
+                whisky_payload.get("attributes", []),
+                "attribute",
+            )
+        )
+        _restore_timestamps(whisky, whisky_payload, ["created", "modified"])
+        whisky_map[whisky_payload["backup_id"]] = whisky
+
+        for barcode_payload in whisky_payload.get("barcodes", []):
+            barcode = WhiskyBarcode.objects.create(
+                whisky=whisky,
+                user=user,
+                household=household,
+                barcode=barcode_payload["barcode"],
+            )
+            _restore_timestamps(barcode, barcode_payload, ["created"])
+
+        for image_payload in whisky_payload.get("images", []):
+            image = WhiskyImage(
+                whisky=whisky,
+                user=user,
+                image_type=image_payload["image_type"],
+                is_primary=image_payload["is_primary"],
+            )
+            _restore_file(image.image, image_payload.get("image"))
+            _restore_file(image.thumbnail, image_payload.get("thumbnail"))
+            image.save()
+            _restore_timestamps(image, image_payload, ["created"])
+
+        for cask_payload in whisky_payload.get("cask_history", []):
+            CaskHistory.objects.create(
+                whisky=whisky,
+                **_build_field_values(
+                    CaskHistory, cask_payload, WHISKY_CASK_HISTORY_FIELDS
+                ),
+            )
+
+    for collection_payload in data.get("collections", []):
+        collection = Collection.objects.create(
+            user=user,
+            household=household,
+            **_build_field_values(Collection, collection_payload, COLLECTION_FIELDS),
+        )
+        collection.whiskies.set(
+            _require_many(
+                whisky_map,
+                collection_payload.get("whiskies", []),
+                "whisky",
+            )
+        )
+        _restore_timestamps(collection, collection_payload, ["created", "modified"])
+
+    storage_item_map = {}
+    for item_payload in data.get("storage_items", []):
+        item = WhiskyStorageItem.objects.create(
+            user=user,
+            household=household,
+            storage=_require_mapping(storage_map, item_payload["storage"], "storage"),
+            whisky=_require_mapping(whisky_map, item_payload["whisky"], "whisky"),
+            **_build_field_values(
+                WhiskyStorageItem,
+                item_payload,
+                WHISKY_STORAGE_ITEM_FIELDS,
+            ),
+        )
+        _restore_timestamps(item, item_payload, ["created", "modified"])
+        storage_item_map[item_payload["backup_id"]] = item
+
+    for wishlist_payload in data.get("wishlists", []):
+        wishlist = WhiskyWishlist.objects.create(
+            user=user,
+            household=household,
+            region=_require_mapping(
+                region_map,
+                wishlist_payload.get("region"),
+                "region",
+            ),
+            distillery=_require_mapping(
+                distillery_map,
+                wishlist_payload.get("distillery"),
+                "distillery",
+            ),
+            **_build_field_values(
+                WhiskyWishlist,
+                wishlist_payload,
+                WHISKY_WISHLIST_FIELDS,
+            ),
+        )
+        _restore_timestamps(wishlist, wishlist_payload, ["created", "modified"])
+
+    for note_payload in data.get("bottle_notes", []):
+        note = WhiskyBottleNote.objects.create(
+            user=user,
+            household=household,
+            storage_item=_require_mapping(
+                storage_item_map,
+                note_payload["storage_item"],
+                "storage item",
+            ),
+            **_build_field_values(
+                WhiskyBottleNote,
+                note_payload,
+                WHISKY_BOTTLE_NOTE_FIELDS,
+            ),
+        )
+        _restore_timestamps(note, note_payload, ["created", "modified"])
+
+    for record_payload in data.get("drink_records", []):
+        record = WhiskyDrinkRecord.objects.create(
+            user=user,
+            household=household,
+            whisky=_require_mapping(whisky_map, record_payload["whisky"], "whisky"),
+            storage_item=_require_mapping(
+                storage_item_map,
+                record_payload.get("storage_item"),
+                "storage item",
+            ),
+            **_build_field_values(
+                WhiskyDrinkRecord,
+                record_payload,
+                WHISKY_DRINK_RECORD_FIELDS,
+            ),
+        )
+        _restore_timestamps(record, record_payload, ["created", "modified"])
+
+    for alert_payload in data.get("alerts", []):
+        alert = WhiskyDrinkingWindowAlert.objects.create(
+            user=user,
+            household=household,
+            whisky=_require_mapping(whisky_map, alert_payload["whisky"], "whisky"),
+            **_build_field_values(
+                WhiskyDrinkingWindowAlert,
+                alert_payload,
+                WHISKY_ALERT_FIELDS,
+            ),
+        )
+        _restore_timestamps(alert, alert_payload, ["created", "modified"])
+
+    for reminder_payload in data.get("reorder_reminders", []):
+        reminder = WhiskyReorderReminder.objects.create(
+            user=user,
+            household=household,
+            whisky=_require_mapping(whisky_map, reminder_payload["whisky"], "whisky"),
+            **_build_field_values(
+                WhiskyReorderReminder,
+                reminder_payload,
+                WHISKY_REMINDER_FIELDS,
+            ),
+        )
+        _restore_timestamps(reminder, reminder_payload, ["created", "modified"])
+
+    for price_payload in data.get("price_history", []):
+        record = WhiskyPriceHistory.objects.create(
+            user=user,
+            household=household,
+            whisky=_require_mapping(whisky_map, price_payload["whisky"], "whisky"),
+            source=_require_mapping(source_map, price_payload.get("source"), "source"),
+            **_build_field_values(WhiskyPriceHistory, price_payload, ["price"]),
+        )
+        _restore_timestamps(record, price_payload, ["recorded_at"])
+
+    for history_payload in data.get("move_history", []):
+        history = WhiskyBottleMoveHistory.objects.create(
+            user=user,
+            storage_item=_require_mapping(
+                storage_item_map,
+                history_payload["storage_item"],
+                "storage item",
+            ),
+            from_storage=_require_mapping(
+                storage_map,
+                history_payload.get("from_storage"),
+                "storage",
+            ),
+            to_storage=_require_mapping(
+                storage_map,
+                history_payload.get("to_storage"),
+                "storage",
+            ),
+            **_build_field_values(
+                WhiskyBottleMoveHistory,
+                history_payload,
+                MOVE_HISTORY_FIELDS,
+            ),
+        )
+        _restore_timestamps(history, history_payload, ["moved_at"])
+
+    return {
+        "app_type": "whisky",
+        "beverages": len(whisky_map),
+        "storages": len(storage_map),
+        "bottles": len(storage_item_map),
+    }
+
+
+def _restore_reference_items(*, items, model_class, user, household, fields):
+    restored = {}
+    for item_payload in items:
+        obj = model_class.objects.create(
+            user=user,
+            household=household,
+            **_build_field_values(model_class, item_payload, fields),
+        )
+        _restore_timestamps(obj, item_payload, ["created", "modified"])
+        restored[item_payload["backup_id"]] = obj
+    return restored

--- a/wine_cellar/apps/user/backup.py
+++ b/wine_cellar/apps/user/backup.py
@@ -209,10 +209,13 @@ def build_backup_response(user, household) -> HttpResponse:
     payload = export_backup_payload(user, household)
     app_type = payload["app_type"]
     today = timezone.localdate().isoformat()
-    response = HttpResponse(
-        json.dumps(payload, indent=2, cls=DjangoJSONEncoder, ensure_ascii=False),
-        content_type=BACKUP_CONTENT_TYPE,
-    )
+    body = json.dumps(payload, indent=2, cls=DjangoJSONEncoder, ensure_ascii=False)
+    if len(body.encode("utf-8")) > MAX_BACKUP_SIZE:
+        raise BackupImportError(
+            f"Backup exceeds maximum size of {MAX_BACKUP_SIZE // (1024 * 1024)}MB "
+            "and cannot be exported. Reduce the number of images or cellar entries."
+        )
+    response = HttpResponse(body, content_type=BACKUP_CONTENT_TYPE)
     response["Content-Disposition"] = (
         f'attachment; filename="{app_type}_backup_{today}.json"'
     )
@@ -226,7 +229,7 @@ def export_backup_payload(user, household) -> dict:
         "exported_at": timezone.now(),
         "household": {"name": household.name},
         "user_settings": _export_simple_fields(
-            user.user_settings, USER_SETTINGS_FIELDS
+            getattr(user, "user_settings", None), USER_SETTINGS_FIELDS
         ),
         "household_settings": _export_simple_fields(
             household.settings if hasattr(household, "settings") else None,
@@ -452,11 +455,11 @@ def _export_wine_backup(user, household) -> dict:
                     if isinstance(wine.appellation, Appellation)
                     else None
                 ),
-                "grapes": list(wine.grapes.values_list("pk", flat=True)),
-                "attributes": list(wine.attributes.values_list("pk", flat=True)),
-                "food_pairings": list(wine.food_pairings.values_list("pk", flat=True)),
-                "vineyard": list(wine.vineyard.values_list("pk", flat=True)),
-                "source": list(wine.source.values_list("pk", flat=True)),
+                "grapes": [obj.pk for obj in wine.grapes.all()],
+                "attributes": [obj.pk for obj in wine.attributes.all()],
+                "food_pairings": [obj.pk for obj in wine.food_pairings.all()],
+                "vineyard": [obj.pk for obj in wine.vineyard.all()],
+                "source": [obj.pk for obj in wine.source.all()],
                 "barcodes": [
                     {"barcode": barcode.barcode, "created": barcode.created}
                     for barcode in wine.barcodes.all().order_by("pk")
@@ -477,7 +480,7 @@ def _export_wine_backup(user, household) -> dict:
             {
                 "backup_id": collection.pk,
                 **_export_simple_fields(collection, COLLECTION_FIELDS),
-                "wines": list(collection.wines.values_list("pk", flat=True)),
+                "wines": [w.pk for w in collection.wines.all()],
             }
             for collection in collections.order_by("pk")
         ],
@@ -691,7 +694,7 @@ def _export_whisky_backup(user, household) -> dict:
                 "distillery": whisky.distillery_id,
                 "bottler": whisky.bottler_id,
                 "source": whisky.source_id,
-                "attributes": list(whisky.attributes.values_list("pk", flat=True)),
+                "attributes": [a.pk for a in whisky.attributes.all()],
                 "barcodes": [
                     {"barcode": barcode.barcode, "created": barcode.created}
                     for barcode in whisky.barcodes.all().order_by("pk")
@@ -720,7 +723,7 @@ def _export_whisky_backup(user, household) -> dict:
             {
                 "backup_id": collection.pk,
                 **_export_simple_fields(collection, COLLECTION_FIELDS),
-                "whiskies": list(collection.whiskies.values_list("pk", flat=True)),
+                "whiskies": [w.pk for w in collection.whiskies.all()],
             }
             for collection in Collection.objects.filter(household=household)
             .prefetch_related("whiskies")
@@ -1086,7 +1089,7 @@ def _restore_wine_backup(data: dict, *, user, household) -> dict:
             source=_require_mapping(source_map, price_payload.get("source"), "source"),
             **_build_field_values(PriceHistory, price_payload, ["price"]),
         )
-        _restore_timestamps(record, price_payload, ["recorded_at"])
+        _restore_timestamps(record, price_payload, ["recorded_at", "created", "modified"])
 
     for history_payload in data.get("move_history", []):
         history = BottleMoveHistory.objects.create(
@@ -1421,7 +1424,7 @@ def _restore_whisky_backup(data: dict, *, user, household) -> dict:
             source=_require_mapping(source_map, price_payload.get("source"), "source"),
             **_build_field_values(WhiskyPriceHistory, price_payload, ["price"]),
         )
-        _restore_timestamps(record, price_payload, ["recorded_at"])
+        _restore_timestamps(record, price_payload, ["recorded_at", "created", "modified"])
 
     for history_payload in data.get("move_history", []):
         history = WhiskyBottleMoveHistory.objects.create(

--- a/wine_cellar/apps/user/backup.py
+++ b/wine_cellar/apps/user/backup.py
@@ -248,7 +248,8 @@ def restore_backup_file(uploaded_file, *, user, household) -> dict:
         raw = uploaded_file.read()
         if len(raw) > MAX_BACKUP_SIZE:
             raise BackupImportError(
-                f"Backup file exceeds maximum size of {MAX_BACKUP_SIZE // (1024 * 1024)}MB."
+                "Backup file exceeds maximum size of "
+                f"{MAX_BACKUP_SIZE // (1024 * 1024)}MB."
             )
         payload = json.loads(raw.decode("utf-8"))
     except (AttributeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -318,7 +319,7 @@ def _restore_file(field_file, file_payload: dict | None) -> None:
         field_file.save(filename, content, save=False)
     except (binascii.Error, ValueError) as exc:
         raise BackupImportError(
-            f"Failed to restore file: invalid data encoding."
+            "Failed to restore file: invalid data encoding."
         ) from exc
 
 
@@ -1089,7 +1090,11 @@ def _restore_wine_backup(data: dict, *, user, household) -> dict:
             source=_require_mapping(source_map, price_payload.get("source"), "source"),
             **_build_field_values(PriceHistory, price_payload, ["price"]),
         )
-        _restore_timestamps(record, price_payload, ["recorded_at", "created", "modified"])
+        _restore_timestamps(
+            record,
+            price_payload,
+            ["recorded_at", "created", "modified"],
+        )
 
     for history_payload in data.get("move_history", []):
         history = BottleMoveHistory.objects.create(
@@ -1424,7 +1429,11 @@ def _restore_whisky_backup(data: dict, *, user, household) -> dict:
             source=_require_mapping(source_map, price_payload.get("source"), "source"),
             **_build_field_values(WhiskyPriceHistory, price_payload, ["price"]),
         )
-        _restore_timestamps(record, price_payload, ["recorded_at", "created", "modified"])
+        _restore_timestamps(
+            record,
+            price_payload,
+            ["recorded_at", "created", "modified"],
+        )
 
     for history_payload in data.get("move_history", []):
         history = WhiskyBottleMoveHistory.objects.create(

--- a/wine_cellar/apps/user/forms.py
+++ b/wine_cellar/apps/user/forms.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.forms import ModelForm
 
 from wine_cellar.apps.user.models import UserSettings
@@ -23,3 +24,23 @@ class UserSettingsForm(ModelForm):
                 "How many years before the drink-by date to start reminding."
             ),
         }
+
+
+class UserBackupImportForm(forms.Form):
+    backup_file = forms.FileField(
+        label="Backup file",
+        help_text="Upload a backup JSON file exported from this app.",
+    )
+    confirm_replace = forms.BooleanField(
+        label="Replace current cellar data",
+        help_text=(
+            "This will overwrite the current household's wines or whiskies,"
+            " bottles, notes, and history."
+        ),
+    )
+
+    def clean_backup_file(self):
+        backup_file = self.cleaned_data["backup_file"]
+        if not backup_file.name.lower().endswith(".json"):
+            raise forms.ValidationError("Backup files must be JSON exports.")
+        return backup_file

--- a/wine_cellar/apps/user/templates/settings.html
+++ b/wine_cellar/apps/user/templates/settings.html
@@ -43,6 +43,27 @@
                         Enable Push Notifications
                     </button>
                 </div>
+                <div class="push-section">
+                    <h2>Data Backup</h2>
+                    {% if active_household %}
+                        <p>Export or restore the current household's cellar data, including bottles, notes, and history.</p>
+                        <p>
+                            <a href="{{ backup_export_url }}" class="pure-button button__secondary">Export backup JSON</a>
+                        </p>
+                        <form method="post"
+                              action="{{ backup_import_url }}"
+                              enctype="multipart/form-data"
+                              class="pure-form pure-form-stacked wine-form"
+                              novalidate>
+                            {% csrf_token %}
+                            {% include 'forms/form_field.html' with field=backup_import_form.backup_file %}
+                            {% include 'forms/form_field.html' with field=backup_import_form.confirm_replace %}
+                            <button type="submit" class="pure-button button__primary">Restore backup</button>
+                        </form>
+                    {% else %}
+                        <p>Select a household before exporting or restoring a backup.</p>
+                    {% endif %}
+                </div>
             </div>
         </div>
     </div>

--- a/wine_cellar/apps/user/views.py
+++ b/wine_cellar/apps/user/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import UpdateView, View
 
-from wine_cellar.apps.household.mixins import RequireHouseholdMixin, RequireAdminMixin
+from wine_cellar.apps.household.mixins import RequireAdminMixin, RequireHouseholdMixin
 from wine_cellar.apps.user.backup import (
     BackupImportError,
     build_backup_response,

--- a/wine_cellar/apps/user/views.py
+++ b/wine_cellar/apps/user/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import UpdateView, View
 
-from wine_cellar.apps.household.mixins import RequireHouseholdMixin, RequireMemberMixin
+from wine_cellar.apps.household.mixins import RequireHouseholdMixin, RequireAdminMixin
 from wine_cellar.apps.user.backup import (
     BackupImportError,
     build_backup_response,
@@ -46,7 +46,7 @@ class UserBackupExportView(LoginRequiredMixin, RequireHouseholdMixin, View):
         return build_backup_response(request.user, household)
 
 
-class UserBackupImportView(LoginRequiredMixin, RequireMemberMixin, View):
+class UserBackupImportView(LoginRequiredMixin, RequireAdminMixin, View):
     def post(self, request, *args, **kwargs):
         form = UserBackupImportForm(request.POST, request.FILES)
         if not form.is_valid():

--- a/wine_cellar/apps/user/views.py
+++ b/wine_cellar/apps/user/views.py
@@ -1,16 +1,25 @@
 from typing import TYPE_CHECKING
 
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
-from django.views.generic import UpdateView
+from django.views.generic import UpdateView, View
 
-from wine_cellar.apps.user.forms import UserSettingsForm
+from wine_cellar.apps.household.mixins import RequireHouseholdMixin, RequireMemberMixin
+from wine_cellar.apps.user.backup import (
+    BackupImportError,
+    build_backup_response,
+    restore_backup_file,
+)
+from wine_cellar.apps.user.forms import UserBackupImportForm, UserSettingsForm
 from wine_cellar.apps.user.models import UserSettings
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import AbstractUser
 
 
-class UserSettingsView(UpdateView):
+class UserSettingsView(LoginRequiredMixin, UpdateView):
     template_name = "settings.html"
     form_class = UserSettingsForm
     success_url = reverse_lazy("user-settings")
@@ -18,6 +27,56 @@ class UserSettingsView(UpdateView):
     def get_object(self, queryset=None):
         user = self.request.user
         return get_user_settings(user)  # type: ignore[arg-type]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["backup_import_form"] = kwargs.get(
+            "backup_import_form",
+            UserBackupImportForm(),
+        )
+        context["backup_export_url"] = reverse_lazy("user-backup-export")
+        context["backup_import_url"] = reverse_lazy("user-backup-import")
+        context["active_household"] = get_active_household(self.request.user)
+        return context
+
+
+class UserBackupExportView(LoginRequiredMixin, RequireHouseholdMixin, View):
+    def get(self, request, *args, **kwargs):
+        household = get_active_household(request.user)
+        return build_backup_response(request.user, household)
+
+
+class UserBackupImportView(LoginRequiredMixin, RequireMemberMixin, View):
+    def post(self, request, *args, **kwargs):
+        form = UserBackupImportForm(request.POST, request.FILES)
+        if not form.is_valid():
+            for errors in form.errors.values():
+                for error in errors:
+                    messages.error(request, error)
+            return redirect("user-settings")
+        if not form.cleaned_data.get("confirm_replace"):
+            messages.error(request, "You must confirm data replacement.")
+            return redirect("user-settings")
+
+        try:
+            result = restore_backup_file(
+                form.cleaned_data["backup_file"],
+                user=request.user,
+                household=get_active_household(request.user),
+            )
+        except BackupImportError as exc:
+            messages.error(request, str(exc))
+            return redirect("user-settings")
+
+        beverage_label = "whiskies" if result["app_type"] == "whisky" else "wines"
+        messages.success(
+            request,
+            "Backup restored: "
+            f"{result['beverages']} {beverage_label}, "
+            f"{result['bottles']} bottles, and "
+            f"{result['storages']} storages.",
+        )
+        return redirect("user-settings")
 
 
 def get_user_settings(user: "AbstractUser") -> UserSettings:

--- a/wine_cellar/apps/user/views.py
+++ b/wine_cellar/apps/user/views.py
@@ -43,7 +43,11 @@ class UserSettingsView(LoginRequiredMixin, UpdateView):
 class UserBackupExportView(LoginRequiredMixin, RequireHouseholdMixin, View):
     def get(self, request, *args, **kwargs):
         household = get_active_household(request.user)
-        return build_backup_response(request.user, household)
+        try:
+            return build_backup_response(request.user, household)
+        except BackupImportError as exc:
+            messages.error(request, str(exc))
+            return redirect("user-settings")
 
 
 class UserBackupImportView(LoginRequiredMixin, RequireAdminMixin, View):

--- a/wine_cellar/conf/urls.py
+++ b/wine_cellar/conf/urls.py
@@ -29,7 +29,11 @@ from wine_cellar.apps.core.api import (
     api_version,
 )
 from wine_cellar.apps.core.pwa import manifest_json, service_worker_js
-from wine_cellar.apps.user.views import UserSettingsView
+from wine_cellar.apps.user.views import (
+    UserBackupExportView,
+    UserBackupImportView,
+    UserSettingsView,
+)
 
 logger = logging.getLogger("wine_cellar.health_check")
 
@@ -122,6 +126,16 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("household/", include("wine_cellar.apps.household.urls")),
     path("user/settings/", UserSettingsView.as_view(), name="user-settings"),
+    path(
+        "user/settings/backup/export/",
+        UserBackupExportView.as_view(),
+        name="user-backup-export",
+    ),
+    path(
+        "user/settings/backup/import/",
+        UserBackupImportView.as_view(),
+        name="user-backup-import",
+    ),
     # Storage (shared across wine/whisky)
     path("", include("wine_cellar.apps.storage.urls")),
     # Shared utilities

--- a/wine_cellar/templates/base.html
+++ b/wine_cellar/templates/base.html
@@ -71,6 +71,15 @@
             {% block header %}
                 <h1 class="brand-title">{{ APP_NAME }}</h1>
             {% endblock header %}
+            {% if messages %}
+                <div class="pure-g">
+                    <div class="pure-u-1">
+                        {% for message in messages %}
+                            <div class="pure-alert alert-{{ message.tags|default:'info' }}">{{ message }}</div>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
             {% block allauth_wrapper %}
                 {% block content %}
                 {% endblock content %}

--- a/wine_cellar/templates/base.html
+++ b/wine_cellar/templates/base.html
@@ -75,7 +75,13 @@
                 <div class="pure-g">
                     <div class="pure-u-1">
                         {% for message in messages %}
-                            <div class="pure-alert alert-{{ message.tags|default:'info' }}">{{ message }}</div>
+                            {% if message.level_tag == 'error' %}
+                                <div class="alert alert--danger">{{ message }}</div>
+                            {% elif message.level_tag == 'warning' %}
+                                <div class="alert alert--warning">{{ message }}</div>
+                            {% else %}
+                                <div class="alert">{{ message }}</div>
+                            {% endif %}
                         {% endfor %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add a settings-based export/import flow for wine and whisky household backups
- include bottles, notes, history, collections, settings, and uploaded images in the backup payload
- add wine and whisky regression coverage for export and restore

Closes #119