### PR TITLE
Add CSV import workflow for wine and whisky

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,3 +14,4 @@ django-ratelimit==4.1.0
 qrcode==8.2
 pywebpush==2.3.0
 djangorestframework==3.16.0
+openpyxl==3.1.5

--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from http import HTTPStatus
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils import timezone
 
@@ -129,6 +130,55 @@ class TestExportViews:
     def test_export_requires_login(self, client):
         r = client.get(reverse("wine-export-csv"))
         assert r.status_code == HTTPStatus.FOUND  # redirect to login
+
+
+@pytest.mark.django_db
+class TestWineImportView:
+    def test_import_creates_wine_and_stock(self, client, user, storage_factory):
+        storage = storage_factory(
+            user=user,
+            household=user.user_settings.active_household,
+            rows=0,
+            columns=0,
+            app_type="wine",
+        )
+        client.force_login(user)
+
+        csv_file = SimpleUploadedFile(
+            "wines.csv",
+            (
+                "name,type,country,stock,price,grapes\n"
+                "Imported Riesling,White,DE,2,12.50,Riesling\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        preview = client.post(
+            reverse("wine-import"),
+            {"action": "upload", "file": csv_file},
+        )
+        assert preview.status_code == HTTPStatus.OK
+        assert "Step 2: Map columns" in preview.content.decode()
+
+        response = client.post(
+            reverse("wine-import"),
+            {
+                "action": "import",
+                "default_storage": storage.pk,
+                "map_name": "name",
+                "map_wine_type": "type",
+                "map_country": "country",
+                "map_stock_count": "stock",
+                "map_price": "price",
+                "map_grapes": "grapes",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        wine = Wine.objects.get(name="Imported Riesling")
+        assert wine.grapes.filter(name="Riesling").exists()
+        assert StorageItem.objects.filter(wine=wine, deleted=False).count() == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -232,8 +232,22 @@ class TestWineImportView:
         assert response.status_code == HTTPStatus.OK
         wine_a = Wine.objects.get(name="Wine A")
         wine_b = Wine.objects.get(name="Wine B")
-        assert StorageItem.objects.filter(wine=wine_a, storage=storage1, deleted=False).count() == 1
-        assert StorageItem.objects.filter(wine=wine_b, storage=storage2, deleted=False).count() == 1
+        assert (
+            StorageItem.objects.filter(
+                wine=wine_a,
+                storage=storage1,
+                deleted=False,
+            ).count()
+            == 1
+        )
+        assert (
+            StorageItem.objects.filter(
+                wine=wine_b,
+                storage=storage2,
+                deleted=False,
+            ).count()
+            == 1
+        )
 
     def test_import_with_bottle_price_mapping(self, client, user, storage_factory):
         """Test that bottle price is correctly parsed and stored."""
@@ -281,10 +295,10 @@ class TestWineImportView:
         assert response.status_code == HTTPStatus.OK
         expensive = Wine.objects.get(name="Expensive Wine")
         cheap = Wine.objects.get(name="Cheap Wine")
-        
+
         expensive_items = StorageItem.objects.filter(wine=expensive, deleted=False)
         cheap_items = StorageItem.objects.filter(wine=cheap, deleted=False)
-        
+
         assert all(Decimal("45.99") == item.price for item in expensive_items)
         assert all(Decimal("8.50") == item.price for item in cheap_items)
 

--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -180,6 +180,114 @@ class TestWineImportView:
         assert wine.grapes.filter(name="Riesling").exists()
         assert StorageItem.objects.filter(wine=wine, deleted=False).count() == 2
 
+    def test_import_with_storage_name_mapping(self, client, user, storage_factory):
+        """Test that storage name mapping creates stock in correct storage."""
+        storage1 = storage_factory(
+            user=user,
+            household=user.user_settings.active_household,
+            name="Cellar A",
+            rows=0,
+            columns=0,
+            app_type="wine",
+        )
+        storage2 = storage_factory(
+            user=user,
+            household=user.user_settings.active_household,
+            name="Cellar B",
+            rows=0,
+            columns=0,
+            app_type="wine",
+        )
+        client.force_login(user)
+
+        csv_file = SimpleUploadedFile(
+            "wines.csv",
+            (
+                "name,type,country,storage,stock\n"
+                "Wine A,White,FR,Cellar A,1\n"
+                "Wine B,Red,IT,Cellar B,1\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        preview = client.post(
+            reverse("wine-import"),
+            {"action": "upload", "file": csv_file},
+        )
+        assert preview.status_code == HTTPStatus.OK
+
+        response = client.post(
+            reverse("wine-import"),
+            {
+                "action": "import",
+                "map_name": "name",
+                "map_wine_type": "type",
+                "map_country": "country",
+                "map_stock_count": "stock",
+                "map_storage_name": "storage",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        wine_a = Wine.objects.get(name="Wine A")
+        wine_b = Wine.objects.get(name="Wine B")
+        assert StorageItem.objects.filter(wine=wine_a, storage=storage1, deleted=False).count() == 1
+        assert StorageItem.objects.filter(wine=wine_b, storage=storage2, deleted=False).count() == 1
+
+    def test_import_with_bottle_price_mapping(self, client, user, storage_factory):
+        """Test that bottle price is correctly parsed and stored."""
+        from decimal import Decimal
+
+        storage = storage_factory(
+            user=user,
+            household=user.user_settings.active_household,
+            rows=0,
+            columns=0,
+            app_type="wine",
+        )
+        client.force_login(user)
+
+        csv_file = SimpleUploadedFile(
+            "wines.csv",
+            (
+                "name,type,country,stock,bottle_price\n"
+                "Expensive Wine,Red,FR,2,45.99\n"
+                "Cheap Wine,White,PT,1,8.50\n"
+            ).encode("utf-8"),
+            content_type="text/csv",
+        )
+
+        preview = client.post(
+            reverse("wine-import"),
+            {"action": "upload", "file": csv_file},
+        )
+        assert preview.status_code == HTTPStatus.OK
+
+        response = client.post(
+            reverse("wine-import"),
+            {
+                "action": "import",
+                "default_storage": storage.pk,
+                "map_name": "name",
+                "map_wine_type": "type",
+                "map_country": "country",
+                "map_stock_count": "stock",
+                "map_bottle_price": "bottle_price",
+            },
+            follow=True,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        expensive = Wine.objects.get(name="Expensive Wine")
+        cheap = Wine.objects.get(name="Cheap Wine")
+        
+        expensive_items = StorageItem.objects.filter(wine=expensive, deleted=False)
+        cheap_items = StorageItem.objects.filter(wine=cheap, deleted=False)
+        
+        assert all(Decimal("45.99") == item.price for item in expensive_items)
+        assert all(Decimal("8.50") == item.price for item in cheap_items)
+
 
 # ---------------------------------------------------------------------------
 # Wine delete view (soft delete)

--- a/tests/test_importing.py
+++ b/tests/test_importing.py
@@ -1,0 +1,30 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from wine_cellar.apps.core.importing import parse_import_excel
+
+
+class FakeWorksheet:
+    max_row = 2
+
+    def iter_rows(self, values_only=True):
+        yield ("name", "type", "country")
+        yield ("Wine A", "Red")
+
+
+class FakeWorkbook:
+    sheetnames = ["Sheet1"]
+    active = FakeWorksheet()
+
+
+def test_parse_import_excel_handles_short_rows(monkeypatch):
+    uploaded_file = SimpleUploadedFile("wines.xlsx", b"stub")
+
+    monkeypatch.setattr(
+        "wine_cellar.apps.core.importing.load_workbook",
+        lambda *args, **kwargs: FakeWorkbook(),
+    )
+
+    headers, rows = parse_import_excel(uploaded_file)
+
+    assert headers == ["name", "type", "country"]
+    assert rows == [{"name": "Wine A", "type": "Red", "country": ""}]

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -68,6 +68,54 @@ def test_whisky_list_loads(client, user):
 
 
 @pytest.mark.django_db
+def test_whisky_import_creates_whisky_and_stock(client, user, storage_factory):
+    storage = storage_factory(
+        user=user,
+        household=user.user_settings.active_household,
+        rows=0,
+        columns=0,
+        app_type="whisky",
+    )
+    client.force_login(user)
+
+    csv_file = SimpleUploadedFile(
+        "whiskies.csv",
+        (
+            "name,whisky_type,country,stock,distillery\n"
+            "Imported Dram,Single Malt,Scotland,1,New Distillery\n"
+        ).encode("utf-8"),
+        content_type="text/csv",
+    )
+
+    preview = client.post(
+        reverse("whisky-import"),
+        {"action": "upload", "file": csv_file},
+    )
+    assert preview.status_code == HTTPStatus.OK
+    assert "Step 2: Map columns" in preview.content.decode()
+
+    response = client.post(
+        reverse("whisky-import"),
+        {
+            "action": "import",
+            "default_storage": storage.pk,
+            "map_name": "name",
+            "map_whisky_type": "whisky_type",
+            "map_country": "country",
+            "map_stock_count": "stock",
+            "map_distillery": "distillery",
+        },
+        follow=True,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    whisky = Whisky.objects.get(name="Imported Dram")
+    assert whisky.distillery is not None
+    assert whisky.distillery.name == "New Distillery"
+    assert WhiskyStorageItem.objects.filter(whisky=whisky, deleted=False).count() == 1
+
+
+@pytest.mark.django_db
 def test_whisky_list_shows_user_whiskies(
     client, user, whisky_factory, whisky_storage_item_factory
 ):

--- a/wine_cellar/apps/core/forms.py
+++ b/wine_cellar/apps/core/forms.py
@@ -245,8 +245,8 @@ class ReorderReminderForm(forms.Form):
 
 class CsvImportUploadForm(forms.Form):
     file = forms.FileField(
-        label="CSV file",
-        help_text="Upload a UTF-8 CSV file with a header row.",
+        label="CSV or Excel file",
+        help_text="Upload a UTF-8 CSV file or Excel (.xlsx) file with a header row.",
     )
 
 

--- a/wine_cellar/apps/core/forms.py
+++ b/wine_cellar/apps/core/forms.py
@@ -241,3 +241,42 @@ class ReorderReminderForm(forms.Form):
         initial=1,
         help_text="Alert when stock drops to or below this number.",
     )
+
+
+class CsvImportUploadForm(forms.Form):
+    file = forms.FileField(
+        label="CSV file",
+        help_text="Upload a UTF-8 CSV file with a header row.",
+    )
+
+
+class CsvImportMappingForm(forms.Form):
+    default_storage = forms.ModelChoiceField(
+        queryset=Storage.objects.none(),
+        required=False,
+        help_text="Used when the CSV includes stock but does not map a storage column.",
+    )
+
+    def __init__(self, *args, headers, field_specs, user, **kwargs):
+        super().__init__(*args, **kwargs)
+        choices = [("", "Do not import")] + [(header, header) for header in headers]
+        household = get_active_household(user)
+        self.fields["default_storage"].queryset = Storage.objects.filter(
+            household=household, app_type=get_app_type()
+        ).order_by("order", "created")
+        self.field_specs = field_specs
+
+        for field in field_specs:
+            self.fields[f"map_{field.name}"] = forms.ChoiceField(
+                label=field.label,
+                choices=choices,
+                required=False,
+                initial=kwargs.get("initial", {}).get(f"map_{field.name}", ""),
+                help_text=field.help_text,
+            )
+
+    def get_mapping(self):
+        return {
+            field.name: self.cleaned_data.get(f"map_{field.name}", "")
+            for field in self.field_specs
+        }

--- a/wine_cellar/apps/core/import_views.py
+++ b/wine_cellar/apps/core/import_views.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import TemplateView
 
 from wine_cellar.apps.core.forms import CsvImportMappingForm, CsvImportUploadForm
@@ -10,11 +11,11 @@ from wine_cellar.apps.core.importing import (
     parse_import_csv,
     parse_import_excel,
 )
-from wine_cellar.apps.household.mixins import RequireHouseholdMixin
+from wine_cellar.apps.household.mixins import RequireHouseholdMixin, RequireMemberMixin
 from wine_cellar.apps.user.views import get_active_household
 
 
-class BaseCsvImportView(RequireHouseholdMixin, TemplateView):
+class BaseCsvImportView(RequireMemberMixin, TemplateView):
     template_name = "core/beverage_import.html"
     importer_class = None
     list_url_name = None
@@ -97,10 +98,21 @@ class BaseCsvImportView(RequireHouseholdMixin, TemplateView):
         action = request.POST.get("action", "upload")
         if action == "clear":
             self.clear_preview_data()
-            return redirect(request.path)
+            return self._safe_redirect(request, request.path)
         if action == "import":
             return self.handle_import()
         return self.handle_upload()
+    
+    def _safe_redirect(self, request, fallback_url):
+        """Safely redirect to a user-provided URL or fallback."""
+        next_url = (request.GET.get("next") or "").strip()
+        if next_url and url_has_allowed_host_and_scheme(
+            url=next_url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return redirect(next_url)
+        return redirect(fallback_url)
 
     def handle_upload(self):
         upload_form = CsvImportUploadForm(self.request.POST, self.request.FILES)
@@ -136,7 +148,7 @@ class BaseCsvImportView(RequireHouseholdMixin, TemplateView):
         preview = self.get_preview_data()
         if not preview:
             messages.error(self.request, "Upload a CSV file before importing.")
-            return redirect(self.request.path)
+            return self._safe_redirect(self.request, self.request.path)
 
         mapping_form = self.get_mapping_form(data=self.request.POST)
         if mapping_form is None or not mapping_form.is_valid():

--- a/wine_cellar/apps/core/import_views.py
+++ b/wine_cellar/apps/core/import_views.py
@@ -1,0 +1,170 @@
+from django.contrib import messages
+from django.core.exceptions import ValidationError
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.views.generic import TemplateView
+
+from wine_cellar.apps.core.forms import CsvImportMappingForm, CsvImportUploadForm
+from wine_cellar.apps.core.importing import (
+    CsvImportValidationError,
+    parse_import_csv,
+)
+from wine_cellar.apps.household.mixins import RequireHouseholdMixin
+from wine_cellar.apps.user.views import get_active_household
+
+
+class BaseCsvImportView(RequireHouseholdMixin, TemplateView):
+    template_name = "core/beverage_import.html"
+    importer_class = None
+    list_url_name = None
+    session_key = None
+
+    def get_importer(self):
+        return self.importer_class()
+
+    def get_session_key(self):
+        return self.session_key
+
+    def get_preview_data(self):
+        return self.request.session.get(self.get_session_key())
+
+    def clear_preview_data(self):
+        self.request.session.pop(self.get_session_key(), None)
+
+    def store_preview_data(self, *, headers, rows, filename):
+        self.request.session[self.get_session_key()] = {
+            "headers": headers,
+            "rows": rows,
+            "filename": filename,
+        }
+
+    def get_upload_form(self):
+        return CsvImportUploadForm()
+
+    def get_mapping_form(self, data=None):
+        preview = self.get_preview_data()
+        if not preview:
+            return None
+
+        importer = self.get_importer()
+        initial = {
+            f"map_{field_name}": header
+            for field_name, header in importer.suggest_mapping(
+                preview["headers"]
+            ).items()
+        }
+        return CsvImportMappingForm(
+            data=data,
+            headers=preview["headers"],
+            field_specs=importer.field_specs,
+            user=self.request.user,
+            initial=initial,
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        preview = self.get_preview_data()
+        context.setdefault("upload_form", self.get_upload_form())
+        context.setdefault("mapping_form", self.get_mapping_form())
+        context["preview"] = preview
+        context["sample_rows"] = (
+            [
+                [sample_row.get(header, "") for header in preview["headers"]]
+                for sample_row in preview["rows"][:5]
+            ]
+            if preview
+            else []
+        )
+        mapping_form = context.get("mapping_form")
+        context["mapping_rows"] = (
+            [
+                {
+                    "label": field.label,
+                    "required": field.required,
+                    "help_text": field.help_text,
+                    "bound_field": mapping_form[f"map_{field.name}"],
+                }
+                for field in self.get_importer().field_specs
+            ]
+            if mapping_form
+            else []
+        )
+        context["list_url"] = reverse(self.list_url_name)
+        return context
+
+    def post(self, request, *args, **kwargs):
+        action = request.POST.get("action", "upload")
+        if action == "clear":
+            self.clear_preview_data()
+            return redirect(request.path)
+        if action == "import":
+            return self.handle_import()
+        return self.handle_upload()
+
+    def handle_upload(self):
+        upload_form = CsvImportUploadForm(self.request.POST, self.request.FILES)
+        if not upload_form.is_valid():
+            return self.render_to_response(
+                self.get_context_data(upload_form=upload_form)
+            )
+
+        try:
+            headers, rows = parse_import_csv(upload_form.cleaned_data["file"])
+        except ValidationError as exc:
+            upload_form.add_error("file", exc)
+            return self.render_to_response(
+                self.get_context_data(upload_form=upload_form)
+            )
+
+        self.store_preview_data(
+            headers=headers,
+            rows=rows,
+            filename=upload_form.cleaned_data["file"].name,
+        )
+        return self.render_to_response(
+            self.get_context_data(mapping_form=self.get_mapping_form())
+        )
+
+    def handle_import(self):
+        preview = self.get_preview_data()
+        if not preview:
+            messages.error(self.request, "Upload a CSV file before importing.")
+            return redirect(self.request.path)
+
+        mapping_form = self.get_mapping_form(data=self.request.POST)
+        if mapping_form is None or not mapping_form.is_valid():
+            return self.render_to_response(
+                self.get_context_data(mapping_form=mapping_form)
+            )
+
+        importer = self.get_importer()
+        household = get_active_household(self.request.user)
+
+        try:
+            summary = importer.import_rows(
+                user=self.request.user,
+                household=household,
+                rows=preview["rows"],
+                mapping=mapping_form.get_mapping(),
+                default_storage=mapping_form.cleaned_data.get("default_storage"),
+            )
+        except CsvImportValidationError as exc:
+            return self.render_to_response(
+                self.get_context_data(
+                    mapping_form=mapping_form,
+                    row_errors=exc.row_errors,
+                )
+            )
+
+        self.clear_preview_data()
+        messages.success(
+            self.request,
+            "%(created)d created, %(matched)d matched existing, "
+            "%(stock)d bottles added."
+            % {
+                "created": summary.created_beverages,
+                "matched": summary.matched_beverages,
+                "stock": summary.created_stock_items,
+            },
+        )
+        return redirect(self.list_url_name)

--- a/wine_cellar/apps/core/import_views.py
+++ b/wine_cellar/apps/core/import_views.py
@@ -8,6 +8,7 @@ from wine_cellar.apps.core.forms import CsvImportMappingForm, CsvImportUploadFor
 from wine_cellar.apps.core.importing import (
     CsvImportValidationError,
     parse_import_csv,
+    parse_import_excel,
 )
 from wine_cellar.apps.household.mixins import RequireHouseholdMixin
 from wine_cellar.apps.user.views import get_active_household
@@ -108,8 +109,14 @@ class BaseCsvImportView(RequireHouseholdMixin, TemplateView):
                 self.get_context_data(upload_form=upload_form)
             )
 
+        uploaded_file = upload_form.cleaned_data["file"]
+        filename_lower = uploaded_file.name.lower()
+
         try:
-            headers, rows = parse_import_csv(upload_form.cleaned_data["file"])
+            if filename_lower.endswith((".xlsx", ".xls")):
+                headers, rows = parse_import_excel(uploaded_file)
+            else:
+                headers, rows = parse_import_csv(uploaded_file)
         except ValidationError as exc:
             upload_form.add_error("file", exc)
             return self.render_to_response(

--- a/wine_cellar/apps/core/import_views.py
+++ b/wine_cellar/apps/core/import_views.py
@@ -1,8 +1,7 @@
 from django.contrib import messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic import TemplateView
 
 from wine_cellar.apps.core.forms import CsvImportMappingForm, CsvImportUploadForm
@@ -95,6 +94,10 @@ class BaseCsvImportView(RequireMemberMixin, TemplateView):
         return context
 
     def post(self, request, *args, **kwargs):
+        if not self.can_edit():
+            raise PermissionDenied(
+                "You need Member role or higher to perform this action."
+            )
         action = request.POST.get("action", "upload")
         if action == "clear":
             self.clear_preview_data()
@@ -104,14 +107,7 @@ class BaseCsvImportView(RequireMemberMixin, TemplateView):
         return self.handle_upload()
 
     def _safe_redirect(self, request, fallback_url):
-        """Safely redirect to a user-provided URL or fallback."""
-        next_url = (request.GET.get("next") or "").strip()
-        if next_url and url_has_allowed_host_and_scheme(
-            url=next_url,
-            allowed_hosts={request.get_host()},
-            require_https=request.is_secure(),
-        ):
-            return redirect(next_url)
+        """Redirect to the fallback URL (never user-supplied input)."""
         return redirect(fallback_url)
 
     def handle_upload(self):
@@ -125,7 +121,7 @@ class BaseCsvImportView(RequireMemberMixin, TemplateView):
         filename_lower = uploaded_file.name.lower()
 
         try:
-            if filename_lower.endswith((".xlsx", ".xls")):
+            if filename_lower.endswith(".xlsx"):
                 headers, rows = parse_import_excel(uploaded_file)
             else:
                 headers, rows = parse_import_csv(uploaded_file)
@@ -147,7 +143,7 @@ class BaseCsvImportView(RequireMemberMixin, TemplateView):
     def handle_import(self):
         preview = self.get_preview_data()
         if not preview:
-            messages.error(self.request, "Upload a CSV file before importing.")
+            messages.error(self.request, "Upload a CSV or Excel file before importing.")
             return self._safe_redirect(self.request, self.request.path)
 
         mapping_form = self.get_mapping_form(data=self.request.POST)

--- a/wine_cellar/apps/core/import_views.py
+++ b/wine_cellar/apps/core/import_views.py
@@ -11,7 +11,7 @@ from wine_cellar.apps.core.importing import (
     parse_import_csv,
     parse_import_excel,
 )
-from wine_cellar.apps.household.mixins import RequireHouseholdMixin, RequireMemberMixin
+from wine_cellar.apps.household.mixins import RequireMemberMixin
 from wine_cellar.apps.user.views import get_active_household
 
 
@@ -102,7 +102,7 @@ class BaseCsvImportView(RequireMemberMixin, TemplateView):
         if action == "import":
             return self.handle_import()
         return self.handle_upload()
-    
+
     def _safe_redirect(self, request, fallback_url):
         """Safely redirect to a user-provided URL or fallback."""
         next_url = (request.GET.get("next") or "").strip()

--- a/wine_cellar/apps/core/importing.py
+++ b/wine_cellar/apps/core/importing.py
@@ -290,11 +290,13 @@ class BaseCsvBeverageImporter:
                 field_name=field.name,
                 raw_value=raw_value,
                 row=row,
+                mapping=mapping,
                 user=user,
                 household=household,
             )
             if field.name in self.stock_mapping_fields:
-                resolved_stock_data[field.name] = converted
+                storage_key = "storage" if field.name == "storage_name" else field.name
+                resolved_stock_data[storage_key] = converted
                 continue
 
             if field.name in self.multiple_fields:
@@ -336,9 +338,11 @@ class BaseCsvBeverageImporter:
                     form_data["row"] = str(first_row)
                 if first_column is not None:
                     form_data["column"] = str(first_column)
-            bottle_price = self.convert_decimal(
-                resolved_stock_data["bottle_price"], "Bottle price"
-            )
+            bottle_price = resolved_stock_data["bottle_price"]
+            if isinstance(bottle_price, Decimal):
+                bottle_price = bottle_price
+            elif bottle_price is not None:
+                bottle_price = self.convert_decimal(bottle_price, "Bottle price")
             if bottle_price is not None:
                 form_data["bottle_price"] = str(bottle_price)
 
@@ -397,7 +401,7 @@ class BaseCsvBeverageImporter:
     ):
         raise NotImplementedError
 
-    def convert_field_value(self, *, field_name, raw_value, row, user, household):
+    def convert_field_value(self, *, field_name, raw_value, row, mapping, user, household):
         raise NotImplementedError
 
     def format_validation_error(self, exc: ValidationError) -> list[str]:

--- a/wine_cellar/apps/core/importing.py
+++ b/wine_cellar/apps/core/importing.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Q
 from django.http import QueryDict
+from openpyxl import load_workbook
 
 from wine_cellar.apps.storage.models import Storage, get_app_type
 
@@ -76,6 +77,64 @@ def parse_import_csv(uploaded_file):
 
     if not rows:
         raise ValidationError("The CSV file does not contain any data rows.")
+
+    return cleaned_headers, rows
+
+
+def parse_import_excel(uploaded_file):
+    if uploaded_file.size > MAX_IMPORT_FILE_SIZE:
+        raise ValidationError(
+            f"Excel files must be {MAX_IMPORT_FILE_SIZE // 1024}KB or smaller."
+        )
+
+    if not uploaded_file.name.lower().endswith((".xlsx", ".xls")):
+        raise ValidationError("Only Excel files (.xlsx or .xls) are supported.")
+
+    try:
+        workbook = load_workbook(uploaded_file, data_only=True)
+    except Exception as exc:
+        raise ValidationError("Invalid or corrupted Excel file.") from exc
+
+    if not workbook.sheetnames:
+        raise ValidationError("The Excel file does not contain any sheets.")
+
+    worksheet = workbook.active
+    if not worksheet or not worksheet.max_row:
+        raise ValidationError("The Excel sheet is empty.")
+
+    rows_data = []
+    for row in worksheet.iter_rows(values_only=True):
+        rows_data.append(row)
+
+    if not rows_data:
+        raise ValidationError("The Excel file does not contain any data.")
+
+    headers = [str(cell or "").strip() for cell in rows_data[0]]
+    if not any(headers):
+        raise ValidationError("The Excel file must include a header row.")
+
+    cleaned_headers = [header.strip() for header in headers]
+    if any(not header for header in cleaned_headers):
+        raise ValidationError("Excel column headers cannot be blank.")
+
+    normalized_headers = [normalize_import_key(header) for header in cleaned_headers]
+    if len(normalized_headers) != len(set(normalized_headers)):
+        raise ValidationError("Excel column headers must be unique.")
+
+    rows = []
+    for index, row in enumerate(rows_data[1:], start=1):
+        if index > MAX_IMPORT_ROWS:
+            raise ValidationError(
+                f"Excel imports are limited to {MAX_IMPORT_ROWS} rows."
+            )
+        cleaned_row = {
+            header: str(row[i] or "").strip()
+            for i, header in enumerate(cleaned_headers)
+        }
+        rows.append(cleaned_row)
+
+    if not rows:
+        raise ValidationError("The Excel file does not contain any data rows.")
 
     return cleaned_headers, rows
 

--- a/wine_cellar/apps/core/importing.py
+++ b/wine_cellar/apps/core/importing.py
@@ -401,7 +401,9 @@ class BaseCsvBeverageImporter:
     ):
         raise NotImplementedError
 
-    def convert_field_value(self, *, field_name, raw_value, row, mapping, user, household):
+    def convert_field_value(
+        self, *, field_name, raw_value, row, mapping, user, household
+    ):
         raise NotImplementedError
 
     def format_validation_error(self, exc: ValidationError) -> list[str]:

--- a/wine_cellar/apps/core/importing.py
+++ b/wine_cellar/apps/core/importing.py
@@ -88,7 +88,10 @@ def parse_import_excel(uploaded_file):
         )
 
     if not uploaded_file.name.lower().endswith(".xlsx"):
-        raise ValidationError("Only Excel (.xlsx) files are supported. Legacy .xls files are not supported.")
+        raise ValidationError(
+            "Only Excel (.xlsx) files are supported. "
+            "Legacy .xls files are not supported."
+        )
 
     try:
         workbook = load_workbook(uploaded_file, data_only=True)

--- a/wine_cellar/apps/core/importing.py
+++ b/wine_cellar/apps/core/importing.py
@@ -87,8 +87,8 @@ def parse_import_excel(uploaded_file):
             f"Excel files must be {MAX_IMPORT_FILE_SIZE // 1024}KB or smaller."
         )
 
-    if not uploaded_file.name.lower().endswith((".xlsx", ".xls")):
-        raise ValidationError("Only Excel files (.xlsx or .xls) are supported.")
+    if not uploaded_file.name.lower().endswith(".xlsx"):
+        raise ValidationError("Only Excel (.xlsx) files are supported. Legacy .xls files are not supported.")
 
     try:
         workbook = load_workbook(uploaded_file, data_only=True)
@@ -359,13 +359,13 @@ class BaseCsvBeverageImporter:
             return []
 
         if storage.rows <= 0 or storage.columns <= 0:
-            if explicit_row or explicit_column:
+            if explicit_row is not None or explicit_column is not None:
                 raise ValidationError(
                     f"Storage “{storage.name}” does not use row/column positions."
                 )
             return [(None, None)] * count
 
-        if explicit_row or explicit_column:
+        if explicit_row is not None or explicit_column is not None:
             if explicit_row is None or explicit_column is None:
                 raise ValidationError("Both row and column are required together.")
             if count != 1:

--- a/wine_cellar/apps/core/importing.py
+++ b/wine_cellar/apps/core/importing.py
@@ -128,7 +128,7 @@ def parse_import_excel(uploaded_file):
                 f"Excel imports are limited to {MAX_IMPORT_ROWS} rows."
             )
         cleaned_row = {
-            header: str(row[i] or "").strip()
+            header: str(row[i] if i < len(row) and row[i] is not None else "").strip()
             for i, header in enumerate(cleaned_headers)
         }
         rows.append(cleaned_row)

--- a/wine_cellar/apps/core/importing.py
+++ b/wine_cellar/apps/core/importing.py
@@ -1,0 +1,480 @@
+import csv
+import io
+import re
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+import pycountry
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Q
+from django.http import QueryDict
+
+from wine_cellar.apps.storage.models import Storage, get_app_type
+
+MAX_IMPORT_FILE_SIZE = 512 * 1024
+MAX_IMPORT_ROWS = 250
+
+TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+
+
+def normalize_import_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", (value or "").strip().casefold())
+
+
+def split_import_values(value: str) -> list[str]:
+    if not value:
+        return []
+    return [part.strip() for part in re.split(r"[,;\n]+", value) if part.strip()]
+
+
+def parse_import_csv(uploaded_file):
+    if uploaded_file.size > MAX_IMPORT_FILE_SIZE:
+        raise ValidationError(
+            f"CSV files must be {MAX_IMPORT_FILE_SIZE // 1024}KB or smaller."
+        )
+
+    if not uploaded_file.name.lower().endswith(".csv"):
+        raise ValidationError("Only CSV files are supported right now.")
+
+    raw_bytes = uploaded_file.read()
+    try:
+        content = raw_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ValidationError("CSV files must be UTF-8 encoded.") from exc
+
+    if not content.strip():
+        raise ValidationError("The uploaded CSV file is empty.")
+
+    sample = content[:2048]
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+    except csv.Error:
+        dialect = csv.excel
+
+    reader = csv.DictReader(io.StringIO(content), dialect=dialect)
+    headers = list(reader.fieldnames or [])
+    if not headers:
+        raise ValidationError("The CSV file must include a header row.")
+
+    cleaned_headers = [header.strip() for header in headers]
+    if any(not header for header in cleaned_headers):
+        raise ValidationError("CSV column headers cannot be blank.")
+
+    normalized_headers = [normalize_import_key(header) for header in cleaned_headers]
+    if len(normalized_headers) != len(set(normalized_headers)):
+        raise ValidationError("CSV column headers must be unique.")
+
+    rows = []
+    for index, row in enumerate(reader, start=1):
+        if index > MAX_IMPORT_ROWS:
+            raise ValidationError(f"CSV imports are limited to {MAX_IMPORT_ROWS} rows.")
+        cleaned_row = {
+            header: (row.get(header) or "").strip() for header in cleaned_headers
+        }
+        rows.append(cleaned_row)
+
+    if not rows:
+        raise ValidationError("The CSV file does not contain any data rows.")
+
+    return cleaned_headers, rows
+
+
+@dataclass(frozen=True)
+class ImportFieldSpec:
+    name: str
+    label: str
+    aliases: tuple[str, ...] = ()
+    required: bool = False
+    help_text: str = ""
+
+
+@dataclass
+class PreparedImportRow:
+    form_data: QueryDict
+    stock_count: int
+    extra_positions: list[tuple[int | None, int | None]]
+
+
+@dataclass
+class ImportSummary:
+    created_beverages: int = 0
+    matched_beverages: int = 0
+    created_stock_items: int = 0
+    skipped_rows: int = 0
+
+
+class CsvImportValidationError(Exception):
+    def __init__(self, row_errors: list[dict]):
+        super().__init__("CSV import validation failed.")
+        self.row_errors = row_errors
+
+
+class BaseCsvBeverageImporter:
+    form_class = None
+    storage_item_model = None
+    beverage_fk_name = None
+    field_specs: tuple[ImportFieldSpec, ...] = ()
+    multiple_fields: frozenset[str] = frozenset()
+    boolean_fields: frozenset[str] = frozenset()
+    stock_mapping_fields: frozenset[str] = frozenset(
+        {"stock_count", "storage_name", "row", "column", "bottle_price"}
+    )
+
+    @property
+    def field_spec_map(self):
+        return {field.name: field for field in self.field_specs}
+
+    def suggest_mapping(self, headers: list[str]) -> dict[str, str]:
+        normalized_headers = {
+            normalize_import_key(header): header for header in headers if header
+        }
+        suggestions = {}
+        for field in self.field_specs:
+            candidates = (field.name, *field.aliases)
+            for candidate in candidates:
+                match = normalized_headers.get(normalize_import_key(candidate))
+                if match:
+                    suggestions[field.name] = match
+                    break
+        return suggestions
+
+    def import_rows(
+        self,
+        *,
+        user,
+        household,
+        rows: list[dict[str, str]],
+        mapping: dict[str, str],
+        default_storage,
+    ) -> ImportSummary:
+        errors = []
+        summary = ImportSummary()
+
+        with transaction.atomic():
+            for row_number, row in enumerate(rows, start=2):
+                if self.row_is_blank(row, mapping):
+                    summary.skipped_rows += 1
+                    continue
+
+                try:
+                    prepared = self.prepare_row(
+                        row=row,
+                        mapping=mapping,
+                        user=user,
+                        household=household,
+                        default_storage=default_storage,
+                    )
+                    form = self.form_class(prepared.form_data, user=user)
+                    if not form.is_valid():
+                        errors.append(
+                            {
+                                "row_number": row_number,
+                                "messages": self.format_form_errors(form),
+                            }
+                        )
+                        continue
+
+                    beverage, created = self.create_beverage(
+                        user=user,
+                        household=household,
+                        cleaned_data=form.cleaned_data,
+                    )
+                    if created:
+                        summary.created_beverages += 1
+                    else:
+                        summary.matched_beverages += 1
+
+                    summary.created_stock_items += prepared.stock_count
+                    for extra_row, extra_column in prepared.extra_positions:
+                        self.create_storage_item(
+                            beverage=beverage,
+                            user=user,
+                            household=household,
+                            cleaned_data=form.cleaned_data,
+                            row=extra_row,
+                            column=extra_column,
+                        )
+                except ValidationError as exc:
+                    errors.append(
+                        {
+                            "row_number": row_number,
+                            "messages": self.format_validation_error(exc),
+                        }
+                    )
+
+            if errors:
+                raise CsvImportValidationError(errors)
+
+        return summary
+
+    def row_is_blank(self, row: dict[str, str], mapping: dict[str, str]) -> bool:
+        for header in mapping.values():
+            if header and row.get(header, "").strip():
+                return False
+        return True
+
+    def prepare_row(self, *, row, mapping, user, household, default_storage):
+        form_data = QueryDict("", mutable=True)
+        resolved_stock_data = {
+            "stock_count": 0,
+            "storage": None,
+            "row": None,
+            "column": None,
+            "bottle_price": None,
+        }
+
+        for field in self.field_specs:
+            header = mapping.get(field.name, "")
+            raw_value = row.get(header, "").strip() if header else ""
+            converted = self.convert_field_value(
+                field_name=field.name,
+                raw_value=raw_value,
+                row=row,
+                user=user,
+                household=household,
+            )
+            if field.name in self.stock_mapping_fields:
+                resolved_stock_data[field.name] = converted
+                continue
+
+            if field.name in self.multiple_fields:
+                form_data.setlist(field.name, converted)
+            elif field.name in self.boolean_fields:
+                if converted:
+                    form_data[field.name] = "on"
+            elif converted not in (None, ""):
+                form_data[field.name] = str(converted)
+
+        stock_count = resolved_stock_data["stock_count"] or 0
+        stock_requested = stock_count > 0 or any(
+            resolved_stock_data.get(key)
+            for key in ("storage", "row", "column", "bottle_price")
+        )
+        storage = resolved_stock_data["storage"] or default_storage
+
+        if stock_requested and storage is None:
+            raise ValidationError(
+                "Select a default storage or map a storage column before "
+                "importing stock."
+            )
+
+        if stock_requested and stock_count <= 0:
+            stock_count = 1
+
+        positions = self.resolve_stock_positions(
+            storage=storage,
+            count=stock_count,
+            explicit_row=resolved_stock_data["row"],
+            explicit_column=resolved_stock_data["column"],
+        )
+
+        if stock_requested:
+            form_data["storage"] = str(storage.pk)
+            if positions:
+                first_row, first_column = positions[0]
+                if first_row is not None:
+                    form_data["row"] = str(first_row)
+                if first_column is not None:
+                    form_data["column"] = str(first_column)
+            bottle_price = self.convert_decimal(
+                resolved_stock_data["bottle_price"], "Bottle price"
+            )
+            if bottle_price is not None:
+                form_data["bottle_price"] = str(bottle_price)
+
+        return PreparedImportRow(
+            form_data=form_data,
+            stock_count=stock_count,
+            extra_positions=(
+                positions[1:] if positions else [(None, None)] * max(stock_count - 1, 0)
+            ),
+        )
+
+    def resolve_stock_positions(self, *, storage, count, explicit_row, explicit_column):
+        if count <= 0:
+            return []
+
+        if storage.rows <= 0 or storage.columns <= 0:
+            if explicit_row or explicit_column:
+                raise ValidationError(
+                    f"Storage “{storage.name}” does not use row/column positions."
+                )
+            return [(None, None)] * count
+
+        if explicit_row or explicit_column:
+            if explicit_row is None or explicit_column is None:
+                raise ValidationError("Both row and column are required together.")
+            if count != 1:
+                raise ValidationError(
+                    "Rows with explicit storage positions can only import one bottle."
+                )
+            if not storage.is_cell_active(explicit_row, explicit_column):
+                raise ValidationError(
+                    f"Storage slot {explicit_row}/{explicit_column} is not active."
+                )
+            if storage.is_slot_occupied(explicit_row, explicit_column):
+                raise ValidationError(
+                    f"Storage slot {explicit_row}/{explicit_column} is already "
+                    "occupied."
+                )
+            return [(explicit_row, explicit_column)]
+
+        free_cells = storage.get_free_cells_by_row()
+        available = [
+            (row, column) for row in sorted(free_cells) for column in free_cells[row]
+        ]
+        if len(available) < count:
+            raise ValidationError(
+                f"Storage “{storage.name}” only has {len(available)} free slots."
+            )
+        return available[:count]
+
+    def create_beverage(self, *, user, household, cleaned_data):
+        raise NotImplementedError
+
+    def create_storage_item(
+        self, *, beverage, user, household, cleaned_data, row, column
+    ):
+        raise NotImplementedError
+
+    def convert_field_value(self, *, field_name, raw_value, row, user, household):
+        raise NotImplementedError
+
+    def format_validation_error(self, exc: ValidationError) -> list[str]:
+        if hasattr(exc, "error_dict"):
+            messages = []
+            for field, errors in exc.message_dict.items():
+                prefix = self.field_spec_map.get(field)
+                field_label = (
+                    prefix.label if prefix else field.replace("_", " ").title()
+                )
+                for error in errors:
+                    messages.append(f"{field_label}: {error}")
+            return messages
+        if hasattr(exc, "messages") and exc.messages:
+            return list(exc.messages)
+        return [str(exc)]
+
+    def format_form_errors(self, form) -> list[str]:
+        messages = []
+        for field, errors in form.errors.items():
+            spec = self.field_spec_map.get(field)
+            field_label = spec.label if spec else field.replace("_", " ").title()
+            for error in errors:
+                messages.append(f"{field_label}: {error}")
+        return messages
+
+    def convert_int(self, value, label):
+        value = (value or "").strip()
+        if not value:
+            return None
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise ValidationError(f"{label} must be a whole number.") from exc
+
+    def convert_decimal(self, value, label):
+        value = (value or "").strip()
+        if not value:
+            return None
+        normalized = value.replace("£", "").replace("$", "").replace("€", "").strip()
+        try:
+            return Decimal(normalized)
+        except InvalidOperation as exc:
+            raise ValidationError(f"{label} must be a valid decimal number.") from exc
+
+    def convert_boolean(self, value):
+        return normalize_import_key(value) in TRUE_VALUES
+
+    def resolve_choice(self, value, choices, label):
+        raw = (value or "").strip()
+        if not raw:
+            return ""
+        normalized = normalize_import_key(raw)
+        choice_map = {}
+        for option in choices:
+            option_value = str(option[0])
+            option_label = str(option[1])
+            choice_map[normalize_import_key(option_value)] = option_value
+            choice_map[normalize_import_key(option_label)] = option_value
+        resolved = choice_map.get(normalized)
+        if resolved is None:
+            raise ValidationError(f"{label} has an unsupported value: {raw}.")
+        return resolved
+
+    def resolve_country_code(self, value, *, allow_whisky_private=False):
+        raw = (value or "").strip()
+        if not raw:
+            return ""
+
+        custom_countries = {}
+        if allow_whisky_private:
+            custom_countries = {
+                "xs": "XS",
+                "scotland": "XS",
+                "xe": "XE",
+                "england": "XE",
+                "xw": "XW",
+                "wales": "XW",
+            }
+
+        if normalize_import_key(raw) in custom_countries:
+            return custom_countries[normalize_import_key(raw)]
+
+        if len(raw) == 2 and raw.upper() not in custom_countries.values():
+            country = pycountry.countries.get(alpha_2=raw.upper())
+            if country:
+                return country.alpha_2
+
+        country = pycountry.countries.get(name=raw)
+        if country is None:
+            country = pycountry.countries.get(common_name=raw)
+        if country is None:
+            try:
+                country = pycountry.countries.search_fuzzy(raw)[0]
+            except LookupError as exc:
+                raise ValidationError(f"Unknown country: {raw}.") from exc
+        return country.alpha_2
+
+    def resolve_storage(self, value, *, household):
+        raw = (value or "").strip()
+        if not raw:
+            return None
+        storage_qs = Storage.objects.filter(
+            household=household, app_type=get_app_type(), name__iexact=raw
+        ).order_by("order", "created")
+        count = storage_qs.count()
+        if count == 0:
+            raise ValidationError(f"Storage “{raw}” does not exist.")
+        if count > 1:
+            raise ValidationError(f"Storage “{raw}” is ambiguous.")
+        return storage_qs.first()
+
+    def resolve_name_values(
+        self,
+        model,
+        value,
+        *,
+        household=None,
+        include_global=False,
+        allow_create=True,
+    ):
+        resolved = []
+        for part in split_import_values(value):
+            queryset = model.objects.all()
+            if household is not None and hasattr(model, "household"):
+                if include_global:
+                    queryset = queryset.filter(
+                        Q(household=household) | Q(household__isnull=True)
+                    )
+                else:
+                    queryset = queryset.filter(household=household)
+            match = queryset.filter(name__iexact=part).first()
+            if match:
+                resolved.append(str(match.pk))
+                continue
+            if not allow_create:
+                raise ValidationError(f"Unknown value: {part}.")
+            resolved.append(f"tom_new_opt{part}")
+        return resolved

--- a/wine_cellar/apps/whisky/importing.py
+++ b/wine_cellar/apps/whisky/importing.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 

--- a/wine_cellar/apps/whisky/importing.py
+++ b/wine_cellar/apps/whisky/importing.py
@@ -1,0 +1,154 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+
+from wine_cellar.apps.core.importing import (
+    BaseCsvBeverageImporter,
+    ImportFieldSpec,
+    split_import_values,
+)
+from wine_cellar.apps.whisky.forms import WhiskyForm
+from wine_cellar.apps.whisky.models import (
+    COMMON_CASK_TYPES,
+    Bottler,
+    BottleSize,
+    Distillery,
+    FillLevel,
+    PeatedLevel,
+    WhiskyRegion,
+    WhiskySource,
+    WhiskyStorageItem,
+    WhiskyType,
+)
+
+
+class WhiskyCsvImporter(BaseCsvBeverageImporter):
+    form_class = WhiskyForm
+    storage_item_model = WhiskyStorageItem
+    beverage_fk_name = "whisky"
+    multiple_fields = frozenset({"cask_type"})
+    boolean_fields = frozenset({"is_gift", "cask_strength"})
+    field_specs = (
+        ImportFieldSpec("name", "Name", required=True),
+        ImportFieldSpec("whisky_type", "Whisky type", aliases=("type",), required=True),
+        ImportFieldSpec("distillery", "Distillery"),
+        ImportFieldSpec("region", "Region"),
+        ImportFieldSpec("country", "Country", required=True),
+        ImportFieldSpec("age_statement", "Age statement"),
+        ImportFieldSpec("vintage_year", "Vintage year"),
+        ImportFieldSpec("bottled_year", "Bottled year"),
+        ImportFieldSpec("abv", "ABV"),
+        ImportFieldSpec("price", "Price"),
+        ImportFieldSpec("size", "Bottle size"),
+        ImportFieldSpec("peated_level", "Peated"),
+        ImportFieldSpec("cask_type", "Cask type"),
+        ImportFieldSpec("cask_strength", "Cask strength"),
+        ImportFieldSpec("bottler", "Bottler"),
+        ImportFieldSpec("source", "Source"),
+        ImportFieldSpec("owner", "Owner"),
+        ImportFieldSpec("rating", "Rating"),
+        ImportFieldSpec("comment", "Comment"),
+        ImportFieldSpec("barcode", "Barcode"),
+        ImportFieldSpec("fill_level", "Fill level"),
+        ImportFieldSpec("stock_count", "Stock count", aliases=("stock", "quantity")),
+        ImportFieldSpec("storage_name", "Storage", aliases=("storage",)),
+        ImportFieldSpec("row", "Storage row"),
+        ImportFieldSpec("column", "Storage column"),
+        ImportFieldSpec("bottle_price", "Bottle price"),
+        ImportFieldSpec("is_gift", "Gift"),
+        ImportFieldSpec("gift_from", "Gift from"),
+        ImportFieldSpec("occasion", "Occasion"),
+    )
+
+    def __init__(self, create_beverage_callback):
+        self._create_beverage_callback = create_beverage_callback
+
+    def create_beverage(self, *, user, household, cleaned_data):
+        return self._create_beverage_callback(user, household, cleaned_data)
+
+    def create_storage_item(
+        self, *, beverage, user, household, cleaned_data, row, column
+    ):
+        fill_level = cleaned_data.get("fill_level") or FillLevel.UNOPENED
+        dreg_date = datetime.date.today() if fill_level == FillLevel.DREG else None
+        bottle_price = cleaned_data.get("bottle_price") or cleaned_data.get("price")
+        WhiskyStorageItem.objects.create(
+            storage=cleaned_data["storage"],
+            whisky=beverage,
+            row=row,
+            column=column,
+            user=user,
+            household=household,
+            price=bottle_price,
+            is_gift=cleaned_data.get("is_gift", False),
+            gift_from=cleaned_data.get("gift_from"),
+            occasion=cleaned_data.get("occasion"),
+            fill_level=fill_level,
+            dreg_date=dreg_date,
+        )
+
+    def convert_field_value(self, *, field_name, raw_value, row, user, household):
+        if field_name in {
+            "name",
+            "owner",
+            "comment",
+            "barcode",
+            "gift_from",
+            "occasion",
+        }:
+            return raw_value
+        if field_name == "whisky_type":
+            return self.resolve_choice(raw_value, WhiskyType.choices, "Whisky type")
+        if field_name == "country":
+            return self.resolve_country_code(raw_value, allow_whisky_private=True)
+        if field_name == "size":
+            if not raw_value.strip():
+                return BottleSize.STANDARD
+            return self.resolve_choice(raw_value, BottleSize.choices, "Bottle size")
+        if field_name == "peated_level":
+            return self.resolve_choice(raw_value, PeatedLevel.choices, "Peated")
+        if field_name == "fill_level":
+            return self.resolve_choice(raw_value, FillLevel.choices, "Fill level")
+        if field_name in {
+            "age_statement",
+            "vintage_year",
+            "bottled_year",
+            "rating",
+            "stock_count",
+            "row",
+            "column",
+        }:
+            return self.convert_int(raw_value, self.field_spec_map[field_name].label)
+        if field_name in {"abv", "price", "bottle_price"}:
+            return self.convert_decimal(
+                raw_value, self.field_spec_map[field_name].label
+            )
+        if field_name in {"is_gift", "cask_strength"}:
+            return self.convert_boolean(raw_value)
+        if field_name == "cask_type":
+            values = split_import_values(raw_value)
+            if not values:
+                return []
+            resolved = []
+            common_types = {value.casefold(): value for value in COMMON_CASK_TYPES}
+            for value in values:
+                resolved.append(common_types.get(value.casefold(), value))
+            return resolved
+        if field_name in {"distillery", "region", "bottler", "source"}:
+            model_map = {
+                "distillery": Distillery,
+                "region": WhiskyRegion,
+                "bottler": Bottler,
+                "source": WhiskySource,
+            }
+            model = model_map[field_name]
+            raw_value = raw_value.strip()
+            if not raw_value:
+                return ""
+            match = model.objects.filter(name__iexact=raw_value).first()
+            if match:
+                return str(match.pk)
+            return f"tom_new_opt{raw_value}"
+        if field_name == "storage_name":
+            return self.resolve_storage(raw_value, household=household)
+        raise ValidationError(f"Unsupported field mapping: {field_name}.")

--- a/wine_cellar/apps/whisky/importing.py
+++ b/wine_cellar/apps/whisky/importing.py
@@ -86,7 +86,9 @@ class WhiskyCsvImporter(BaseCsvBeverageImporter):
             dreg_date=dreg_date,
         )
 
-    def convert_field_value(self, *, field_name, raw_value, row, mapping, user, household):
+    def convert_field_value(
+        self, *, field_name, raw_value, row, mapping, user, household
+    ):
         if field_name in {
             "name",
             "owner",

--- a/wine_cellar/apps/whisky/importing.py
+++ b/wine_cellar/apps/whisky/importing.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 
 from wine_cellar.apps.core.importing import (
     BaseCsvBeverageImporter,
@@ -70,7 +71,7 @@ class WhiskyCsvImporter(BaseCsvBeverageImporter):
         self, *, beverage, user, household, cleaned_data, row, column
     ):
         fill_level = cleaned_data.get("fill_level") or FillLevel.UNOPENED
-        dreg_date = datetime.date.today() if fill_level == FillLevel.DREG else None
+        dreg_date = timezone.localdate() if fill_level == FillLevel.DREG else None
         bottle_price = cleaned_data.get("bottle_price") or cleaned_data.get("price")
         WhiskyStorageItem.objects.create(
             storage=cleaned_data["storage"],
@@ -87,7 +88,7 @@ class WhiskyCsvImporter(BaseCsvBeverageImporter):
             dreg_date=dreg_date,
         )
 
-    def convert_field_value(self, *, field_name, raw_value, row, user, household):
+    def convert_field_value(self, *, field_name, raw_value, row, mapping, user, household):
         if field_name in {
             "name",
             "owner",

--- a/wine_cellar/apps/whisky/urls.py
+++ b/wine_cellar/apps/whisky/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("random/", views.RandomBottleView.as_view(), name="random-bottle"),
     # Whisky CRUD
     path("whiskies/", views.WhiskyListView.as_view(), name="whisky-list"),
+    path("whiskies/import/", views.WhiskyImportView.as_view(), name="whisky-import"),
     path("whisky/add/", views.WhiskyCreateView.as_view(), name="whisky-add"),
     path("whisky/<int:pk>/", views.WhiskyDetailView.as_view(), name="whisky-detail"),
     path(

--- a/wine_cellar/apps/whisky/views.py
+++ b/wine_cellar/apps/whisky/views.py
@@ -20,6 +20,7 @@ from django.views.generic import (
 from django_filters.views import FilterView
 from django_ratelimit.decorators import ratelimit
 
+from wine_cellar.apps.core.import_views import BaseCsvImportView
 from wine_cellar.apps.core.views import (
     MAX_IMAGE_SIZE,
     BaseBeverageCreateView,
@@ -78,6 +79,7 @@ from wine_cellar.apps.whisky.forms import (
     WhiskyStockAddForm,
     WhiskyWishlistForm,
 )
+from wine_cellar.apps.whisky.importing import WhiskyCsvImporter
 from wine_cellar.apps.whisky.models import (
     Bottler,
     Collection,
@@ -671,6 +673,14 @@ class WhiskyListView(BaseListView, FilterView):
     card_template = "whisky/whisky_card.html"
     filter_field_template = "whisky/whisky_filter_field.html"
     beverage_icon = "whiskey-glass"
+
+
+class WhiskyImportView(BaseCsvImportView):
+    list_url_name = "whisky-list"
+    session_key = "whisky_csv_import_preview"
+
+    def get_importer(self):
+        return WhiskyCsvImporter(WhiskyCreateView.process_form_data)
 
 
 class WhiskyScanView(BaseScanView):

--- a/wine_cellar/apps/wine/importing.py
+++ b/wine_cellar/apps/wine/importing.py
@@ -1,0 +1,162 @@
+from django.core.exceptions import ValidationError
+
+from wine_cellar.apps.core.importing import BaseCsvBeverageImporter, ImportFieldSpec
+from wine_cellar.apps.storage.models import StorageItem
+from wine_cellar.apps.wine.forms import WineForm
+from wine_cellar.apps.wine.models import (
+    SIZE_LITERS_TO_CODE,
+    Appellation,
+    Attribute,
+    Category,
+    FoodPairing,
+    Grape,
+    SizeChoices,
+    Source,
+    Vineyard,
+    WineType,
+)
+from wine_cellar.apps.wine.views.wine_crud import WineCreateView
+
+
+class WineCsvImporter(BaseCsvBeverageImporter):
+    form_class = WineForm
+    storage_item_model = StorageItem
+    beverage_fk_name = "wine"
+    multiple_fields = frozenset(
+        {"grapes", "vineyard", "food_pairings", "attributes", "source"}
+    )
+    field_specs = (
+        ImportFieldSpec("name", "Name", required=True),
+        ImportFieldSpec("wine_type", "Wine type", aliases=("type",), required=True),
+        ImportFieldSpec("category", "Sweetness", aliases=("sweetness",)),
+        ImportFieldSpec("country", "Country", required=True),
+        ImportFieldSpec("subregion", "Subregion"),
+        ImportFieldSpec("appellation", "Appellation"),
+        ImportFieldSpec("vintage", "Vintage"),
+        ImportFieldSpec("grapes", "Grapes"),
+        ImportFieldSpec("abv", "ABV"),
+        ImportFieldSpec("rating", "Rating"),
+        ImportFieldSpec("price", "Price"),
+        ImportFieldSpec("size", "Bottle size"),
+        ImportFieldSpec("drink_from", "Drink from"),
+        ImportFieldSpec("drink_to", "Drink to"),
+        ImportFieldSpec("comment", "Comment"),
+        ImportFieldSpec("vineyard", "Vineyard"),
+        ImportFieldSpec("food_pairings", "Food pairings"),
+        ImportFieldSpec("attributes", "Attributes"),
+        ImportFieldSpec("source", "Source"),
+        ImportFieldSpec("barcode", "Barcode"),
+        ImportFieldSpec("stock_count", "Stock count", aliases=("stock", "quantity")),
+        ImportFieldSpec("storage_name", "Storage", aliases=("storage",)),
+        ImportFieldSpec("row", "Storage row"),
+        ImportFieldSpec("column", "Storage column"),
+        ImportFieldSpec("bottle_price", "Bottle price"),
+        ImportFieldSpec("is_gift", "Gift"),
+        ImportFieldSpec("gift_from", "Gift from"),
+        ImportFieldSpec("occasion", "Occasion"),
+    )
+    boolean_fields = frozenset({"is_gift"})
+
+    def create_beverage(self, *, user, household, cleaned_data):
+        return WineCreateView.process_form_data(user, household, cleaned_data)
+
+    def create_storage_item(
+        self, *, beverage, user, household, cleaned_data, row, column
+    ):
+        bottle_price = cleaned_data.get("bottle_price") or cleaned_data.get("price")
+        StorageItem.objects.create(
+            storage=cleaned_data["storage"],
+            wine=beverage,
+            row=row,
+            column=column,
+            user=user,
+            household=household,
+            price=bottle_price,
+            is_gift=cleaned_data.get("is_gift", False),
+            gift_from=cleaned_data.get("gift_from"),
+            occasion=cleaned_data.get("occasion"),
+        )
+
+    def convert_field_value(self, *, field_name, raw_value, row, user, household):
+        if field_name in {
+            "name",
+            "subregion",
+            "comment",
+            "barcode",
+            "gift_from",
+            "occasion",
+        }:
+            return raw_value
+        if field_name == "wine_type":
+            return self.resolve_choice(raw_value, WineType.choices, "Wine type")
+        if field_name == "category":
+            return self.resolve_choice(raw_value, Category.choices, "Sweetness")
+        if field_name == "country":
+            return self.resolve_country_code(raw_value)
+        if field_name == "appellation":
+            raw_value = raw_value.strip()
+            if not raw_value:
+                return ""
+            country_code = (
+                self.resolve_country_code(row.get("country", ""))
+                if row.get("country")
+                else None
+            )
+            qs = Appellation.objects.filter(name__iexact=raw_value)
+            if country_code:
+                qs = qs.filter(country=country_code)
+            appellation = qs.first()
+            if appellation is None:
+                raise ValidationError(f"Unknown appellation: {raw_value}.")
+            return str(appellation.pk)
+        if field_name in {"vintage", "rating", "stock_count", "row", "column"}:
+            return self.convert_int(raw_value, self.field_spec_map[field_name].label)
+        if field_name in {"abv", "price", "bottle_price"}:
+            return self.convert_decimal(
+                raw_value, self.field_spec_map[field_name].label
+            )
+        if field_name == "size":
+            raw_value = raw_value.strip()
+            if not raw_value:
+                return ""
+            if raw_value in SIZE_LITERS_TO_CODE:
+                return SIZE_LITERS_TO_CODE[raw_value]
+            try:
+                liters = float(raw_value)
+            except ValueError:
+                liters = None
+            if liters in SIZE_LITERS_TO_CODE:
+                return SIZE_LITERS_TO_CODE[liters]
+            return self.resolve_choice(raw_value, SizeChoices.choices, "Bottle size")
+        if field_name in {"drink_from", "drink_to"}:
+            raw_value = raw_value.strip()
+            if not raw_value:
+                return ""
+            if raw_value.casefold() == "now":
+                return 0
+            return self.convert_int(raw_value, self.field_spec_map[field_name].label)
+        if field_name in {
+            "grapes",
+            "vineyard",
+            "food_pairings",
+            "attributes",
+            "source",
+        }:
+            model_map = {
+                "grapes": Grape,
+                "vineyard": Vineyard,
+                "food_pairings": FoodPairing,
+                "attributes": Attribute,
+                "source": Source,
+            }
+            return self.resolve_name_values(
+                model_map[field_name],
+                raw_value,
+                household=household,
+                include_global=True,
+            )
+        if field_name == "storage_name":
+            return self.resolve_storage(raw_value, household=household)
+        if field_name == "is_gift":
+            return self.convert_boolean(raw_value)
+        raise ValidationError(f"Unsupported field mapping: {field_name}.")

--- a/wine_cellar/apps/wine/importing.py
+++ b/wine_cellar/apps/wine/importing.py
@@ -77,7 +77,7 @@ class WineCsvImporter(BaseCsvBeverageImporter):
             occasion=cleaned_data.get("occasion"),
         )
 
-    def convert_field_value(self, *, field_name, raw_value, row, user, household):
+    def convert_field_value(self, *, field_name, raw_value, row, mapping, user, household):
         if field_name in {
             "name",
             "subregion",
@@ -97,11 +97,12 @@ class WineCsvImporter(BaseCsvBeverageImporter):
             raw_value = raw_value.strip()
             if not raw_value:
                 return ""
-            country_code = (
-                self.resolve_country_code(row.get("country", ""))
-                if row.get("country")
-                else None
-            )
+            country_code = None
+            country_header = mapping.get("country", "")
+            if country_header:
+                country_raw = row.get(country_header, "").strip()
+                if country_raw:
+                    country_code = self.resolve_country_code(country_raw)
             qs = Appellation.objects.filter(name__iexact=raw_value)
             if country_code:
                 qs = qs.filter(country=country_code)

--- a/wine_cellar/apps/wine/importing.py
+++ b/wine_cellar/apps/wine/importing.py
@@ -77,7 +77,9 @@ class WineCsvImporter(BaseCsvBeverageImporter):
             occasion=cleaned_data.get("occasion"),
         )
 
-    def convert_field_value(self, *, field_name, raw_value, row, mapping, user, household):
+    def convert_field_value(
+        self, *, field_name, raw_value, row, mapping, user, household
+    ):
         if field_name in {
             "name",
             "subregion",

--- a/wine_cellar/apps/wine/urls.py
+++ b/wine_cellar/apps/wine/urls.py
@@ -31,6 +31,7 @@ from wine_cellar.apps.wine.views import (
     WineDeleteView,
     WineDetailView,
     WineImagesView,
+    WineImportView,
     WineListView,
     WineMapView,
     WineMergeConfirmView,
@@ -101,6 +102,7 @@ urlpatterns = [
         "wine/<int:pk>/drink/", DrinkRecordCreateView.as_view(), name="drink-record-add"
     ),
     path("wines/", WineListView.as_view(), name="wine-list"),
+    path("wines/import/", WineImportView.as_view(), name="wine-import"),
     path("wines/export/csv/", export_wines_csv_view, name="wine-export-csv"),
     path("wines/export/json/", export_wines_json_view, name="wine-export-json"),
     path("wines/bulk/", bulk_action_view, name="wine-bulk-action"),

--- a/wine_cellar/apps/wine/views/__init__.py
+++ b/wine_cellar/apps/wine/views/__init__.py
@@ -29,6 +29,7 @@ from wine_cellar.apps.wine.views.home import (  # noqa: F401
     QRCodeView,
     RandomBottleView,
 )
+from wine_cellar.apps.wine.views.imports import WineImportView  # noqa: F401
 from wine_cellar.apps.wine.views.map import WineMapView  # noqa: F401
 from wine_cellar.apps.wine.views.reminders import (  # noqa: F401
     ReorderReminderCreateView,

--- a/wine_cellar/apps/wine/views/imports.py
+++ b/wine_cellar/apps/wine/views/imports.py
@@ -1,0 +1,8 @@
+from wine_cellar.apps.core.import_views import BaseCsvImportView
+from wine_cellar.apps.wine.importing import WineCsvImporter
+
+
+class WineImportView(BaseCsvImportView):
+    importer_class = WineCsvImporter
+    list_url_name = "wine-list"
+    session_key = "wine_csv_import_preview"

--- a/wine_cellar/templates/core/beverage_import.html
+++ b/wine_cellar/templates/core/beverage_import.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+{% block header %}
+    <h1 class="header__title">Import {{ APP_ITEM_NAME_PLURAL|capfirst }}</h1>
+{% endblock header %}
+{% block content %}
+    <div class="pure-g">
+        <div class="pure-u-1 pure-u-lg-2-3">
+            <div class="card">
+                <h2>Step 1: Upload CSV</h2>
+                <p>Upload a CSV file, review the detected columns, then map them to {{ APP_ITEM_NAME }} fields. Excel support can follow in a later update.</p>
+                <form method="post" enctype="multipart/form-data" class="pure-form pure-form-stacked">
+                    {% csrf_token %}
+                    <input type="hidden" name="action" value="upload">
+                    {{ upload_form.as_p }}
+                    <button type="submit" class="pure-button button__primary">Preview columns</button>
+                    <a href="{{ list_url }}" class="pure-button button__secondary">Cancel</a>
+                </form>
+            </div>
+
+            {% if preview %}
+                <div class="card mt-md">
+                    <h2>Step 2: Map columns</h2>
+                    <p><strong>{{ preview.filename }}</strong> · {{ preview.rows|length }} row{{ preview.rows|length|pluralize }}</p>
+                    <form method="post" class="pure-form pure-form-stacked">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="import">
+                        <p>{{ mapping_form.default_storage.label_tag }} {{ mapping_form.default_storage }}</p>
+                        <p class="form-help">{{ mapping_form.default_storage.help_text }}</p>
+                        <table class="pure-table pure-table-striped">
+                            <thead>
+                                <tr>
+                                    <th>Field</th>
+                                    <th>CSV column</th>
+                                    <th>Notes</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for mapping_row in mapping_rows %}
+                                        <tr>
+                                            <td>{{ mapping_row.label }}{% if mapping_row.required %} *{% endif %}</td>
+                                            <td>{{ mapping_row.bound_field }}</td>
+                                            <td>{{ mapping_row.help_text }}</td>
+                                        </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        <div class="mt-md">
+                            <button type="submit" class="pure-button button__primary">Import rows</button>
+                        </div>
+                    </form>
+                    <form method="post" class="mt-md">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="clear">
+                        <button type="submit" class="pure-button button__secondary">Choose a different file</button>
+                    </form>
+                </div>
+
+                <div class="card mt-md">
+                    <h2>Preview</h2>
+                    <div class="storage-list__table-wrapper">
+                        <table class="pure-table pure-table-striped">
+                            <thead>
+                                <tr>
+                                    {% for header in preview.headers %}
+                                        <th>{{ header }}</th>
+                                    {% endfor %}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for sample_row in sample_rows %}
+                                    <tr>
+                                        {% for value in sample_row %}
+                                            <td>{{ value }}</td>
+                                        {% endfor %}
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if row_errors %}
+                <div class="card mt-md">
+                    <h2>Import issues</h2>
+                    <ul>
+                        {% for row_error in row_errors %}
+                            <li>
+                                <strong>Row {{ row_error.row_number }}:</strong>
+                                {{ row_error.messages|join:", " }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock content %}

--- a/wine_cellar/templates/core/beverage_import.html
+++ b/wine_cellar/templates/core/beverage_import.html
@@ -6,8 +6,8 @@
     <div class="pure-g">
         <div class="pure-u-1 pure-u-lg-2-3">
             <div class="card">
-                <h2>Step 1: Upload CSV</h2>
-                <p>Upload a CSV file, review the detected columns, then map them to {{ APP_ITEM_NAME }} fields. Excel support can follow in a later update.</p>
+                <h2>Step 1: Upload CSV or Excel</h2>
+                <p>Upload a CSV or Excel (.xlsx) file, review the detected columns, then map them to {{ APP_ITEM_NAME }} fields.</p>
                 <form method="post" enctype="multipart/form-data" class="pure-form pure-form-stacked">
                     {% csrf_token %}
                     <input type="hidden" name="action" value="upload">
@@ -30,7 +30,7 @@
                             <thead>
                                 <tr>
                                     <th>Field</th>
-                                    <th>CSV column</th>
+                                    <th>Source column</th>
                                     <th>Notes</th>
                                 </tr>
                             </thead>

--- a/wine_cellar/templates/core/beverage_list.html
+++ b/wine_cellar/templates/core/beverage_list.html
@@ -72,9 +72,11 @@
                     {% endfor %}
                 </select>
                 <span class="export-links">
+                    {% if household.current_member.can_edit %}
                     <a href="{% bev_url 'import' %}" class="pure-button button__secondary button--sm" title="Import CSV">
                         <i class="fa-solid fa-file-import"></i> Import
                     </a>
+                    {% endif %}
                     {% if export_csv_url %}
                     <a href="{{ export_csv_url }}" class="pure-button button__secondary button--sm" title="Export CSV">
                         <i class="fa-solid fa-file-csv"></i> CSV
@@ -97,9 +99,11 @@
                          <a href="{% bev_url 'add' %}" class="pure-button button__primary empty-state__action">
                              <i class="fa-solid fa-plus"></i> Add {{ APP_ITEM_NAME }}
                          </a>
+                         {% if household.current_member.can_edit %}
                          <a href="{% bev_url 'import' %}" class="pure-button button__secondary empty-state__action">
                              <i class="fa-solid fa-file-import"></i> Import CSV
                          </a>
+                         {% endif %}
                      </li>
                  {% endfor %}
              </ul>

--- a/wine_cellar/templates/core/beverage_list.html
+++ b/wine_cellar/templates/core/beverage_list.html
@@ -71,18 +71,21 @@
                         <option value="{% querystring per_page=option page=1 %}" {% if option == current_per_page %}selected{% endif %}>{{ option }}</option>
                     {% endfor %}
                 </select>
-                {% if export_csv_url %}
                 <span class="export-links">
+                    <a href="{% bev_url 'import' %}" class="pure-button button__secondary button--sm" title="Import CSV">
+                        <i class="fa-solid fa-file-import"></i> Import
+                    </a>
+                    {% if export_csv_url %}
                     <a href="{{ export_csv_url }}" class="pure-button button__secondary button--sm" title="Export CSV">
                         <i class="fa-solid fa-file-csv"></i> CSV
                     </a>
                     <a href="{{ export_json_url }}" class="pure-button button__secondary button--sm" title="Export JSON">
                         <i class="fa-solid fa-file-code"></i> JSON
                     </a>
+                    {% endif %}
                 </span>
-                {% endif %}
-            </div>
-            {% endif %}
+             </div>
+             {% endif %}
             <ul class="wine-card__list">
                 {% for beverage in beverages %}
                     {% include card_template with wine=beverage whisky=beverage %}
@@ -91,12 +94,15 @@
                         <div class="empty-state__icon"><i class="fa-solid fa-{{ beverage_icon }}"></i></div>
                         <h3 class="empty-state__title">No {{ APP_ITEM_NAME_PLURAL }} yet</h3>
                         <p class="empty-state__message">Start building your collection by adding your first {{ APP_ITEM_NAME }}.</p>
-                        <a href="{% bev_url 'add' %}" class="pure-button button__primary empty-state__action">
-                            <i class="fa-solid fa-plus"></i> Add {{ APP_ITEM_NAME }}
-                        </a>
-                    </li>
-                {% endfor %}
-            </ul>
+                         <a href="{% bev_url 'add' %}" class="pure-button button__primary empty-state__action">
+                             <i class="fa-solid fa-plus"></i> Add {{ APP_ITEM_NAME }}
+                         </a>
+                         <a href="{% bev_url 'import' %}" class="pure-button button__secondary empty-state__action">
+                             <i class="fa-solid fa-file-import"></i> Import CSV
+                         </a>
+                     </li>
+                 {% endfor %}
+             </ul>
             {% include "includes/pagination.html" %}
         </div>
     </div>

--- a/wine_cellar/templates/core/beverage_list.html
+++ b/wine_cellar/templates/core/beverage_list.html
@@ -72,7 +72,7 @@
                     {% endfor %}
                 </select>
                 <span class="export-links">
-                    {% if household.current_member.can_edit %}
+                    {% if can_edit %}
                     <a href="{% bev_url 'import' %}" class="pure-button button__secondary button--sm" title="Import CSV">
                         <i class="fa-solid fa-file-import"></i> Import
                     </a>
@@ -99,7 +99,7 @@
                          <a href="{% bev_url 'add' %}" class="pure-button button__primary empty-state__action">
                              <i class="fa-solid fa-plus"></i> Add {{ APP_ITEM_NAME }}
                          </a>
-                         {% if household.current_member.can_edit %}
+                         {% if can_edit %}
                          <a href="{% bev_url 'import' %}" class="pure-button button__secondary empty-state__action">
                              <i class="fa-solid fa-file-import"></i> Import CSV
                          </a>


### PR DESCRIPTION
## Summary\n- add a two-step CSV import flow with upload, column mapping, row previews, and reusable import helpers\n- support creating wine and whisky records in bulk, including stock creation through a mapped/default storage\n- add list-page import entry points and focused wine/whisky import tests\n\n## Scope\n- supports CSV imports today\n- Excel/XLSX support is still outstanding, so this PR advances issue #97 but does not fully close it\n\n## Testing\n- \/root\/wine-cellar-personal\/venv\/bin\/pytest tests\/test_core_views.py -q\n- CELLAR_APP_TYPE=whisky \/root\/wine-cellar-personal\/venv\/bin\/pytest tests\/whisky\/test_views.py -k whisky_import_creates_whisky_and_stock -q\n- \/root\/wine-cellar-personal\/venv\/bin\/python manage.py makemigrations --dry-run --check --noinput\n- black --check / isort --check-only / flake8 on modified Python files\n- djlint wine_cellar\/templates\/core\/beverage_import.html wine_cellar\/templates\/core\/beverage_list.html --profile=django --ignore=H030,H031,T002\n\nRefs #97