### PR TITLE
Raise coverage threshold to 80%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 80
 show_missing = true
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
## Summary
- raise `[tool.coverage.report].fail_under` from 70 to 80
- keep coverage enforcement aligned with the current measured total of 86%
- note that issue #85 was still relevant, but its description was stale because the threshold had already been raised from 59 to 70 in PR #130

## Validation
- `/root/wine-cellar-personal/venv/bin/py.test --reuse-db --cov --cov-report=term-missing:skip-covered`
- `/root/wine-cellar-personal/venv/bin/coverage report` (TOTAL 86%)

Closes #85