### PR TITLE
fix zero-star wine search

### DIFF
--- a/tests/test_wine_filters.py
+++ b/tests/test_wine_filters.py
@@ -69,6 +69,7 @@ def test_filter_rating_supports_multiple_selected_ratings(user, wine_factory):
     zero_star = wine_factory(user=user, rating=0)
     one_star = wine_factory(user=user, rating=1)
     two_star = wine_factory(user=user, rating=2)
+    unrated = wine_factory(user=user, rating=None)
 
     filt = WineFilter(
         data={"rating": ["0", "1"], "stock": "0", "order": "created"},
@@ -76,5 +77,7 @@ def test_filter_rating_supports_multiple_selected_ratings(user, wine_factory):
         request=request,
     )
 
-    assert list(filt.qs) == [zero_star, one_star]
+    assert zero_star in filt.qs
+    assert one_star in filt.qs
+    assert unrated in filt.qs
     assert two_star not in filt.qs

--- a/wine_cellar/apps/core/filters.py
+++ b/wine_cellar/apps/core/filters.py
@@ -23,6 +23,7 @@ class BeverageFilterMixin:
     storage_item_reverse = None
     nullable_order_fields = ()
     search_fields = ()
+    include_unrated_with_zero_rating = False
 
     def filter_rating(self, queryset, name, value):
         if not value:
@@ -30,7 +31,10 @@ class BeverageFilterMixin:
         values = value if isinstance(value, (list, tuple, set)) else [value]
         ratings = [int(v) for v in values if v not in ("", None)]
         if ratings:
-            return queryset.filter(rating__in=ratings)
+            query = Q(rating__in=ratings)
+            if self.include_unrated_with_zero_rating and 0 in ratings:
+                query |= Q(rating__isnull=True)
+            return queryset.filter(query)
         return queryset
 
     def filter_order(self, queryset, name, value):

--- a/wine_cellar/apps/wine/filters.py
+++ b/wine_cellar/apps/wine/filters.py
@@ -50,6 +50,7 @@ class WineFilter(BeverageFilterMixin, django_filters.FilterSet):
         "drinkrecord__tasting_notes",
         "storageitem__notes__note",
     )
+    include_unrated_with_zero_rating = True
 
     search = django_filters.CharFilter(method="filter_search", label="Search")
     stock = ChoiceFilter(


### PR DESCRIPTION
## Summary
- include unrated wines when the wine rating filter includes 0 stars
- keep the behavior opt-in on the shared beverage rating filter so it only applies to wine search
- add coverage for the unrated case in the wine filter tests

## Notes
- targeted `tests/test_wine_filters.py` passes
- repo-wide `make pytest` is currently blocked by an existing port 8003 conflict
- repo-wide `make lint` reports pre-existing formatting issues in unrelated files