### PR TITLE
Move storage utilisation below grid

### DIFF
--- a/wine_cellar/assets/css/storage.css
+++ b/wine_cellar/assets/css/storage.css
@@ -66,6 +66,11 @@
   margin-bottom: var(--spacing-md);
 }
 
+.storage-grid__storage-meta--after-grid {
+  margin-top: var(--spacing-md);
+  margin-bottom: 0;
+}
+
 .storage-grid__storage-meta-item {
   padding: var(--spacing-xs) var(--spacing-sm);
   background-color: var(--gray-100);

--- a/wine_cellar/react/storage_grid.tsx
+++ b/wine_cellar/react/storage_grid.tsx
@@ -126,6 +126,17 @@ const getStorageUtilizationLabel = (storage: StorageData): string => {
     return `${translated.utilisation}: ${storage.used_slots}/${storage.total_slots} ${translated.slotsUsed} (${storage.utilization_percent}% ${translated.full})`;
 };
 
+const renderStorageMeta = (storage: StorageData, className = '') => (
+    <div className={`storage-grid__storage-meta${className ? ` ${className}` : ''}`}>
+        <span className="storage-grid__storage-meta-item">
+            {storage.rows}x{storage.columns}
+        </span>
+        <span className="storage-grid__storage-meta-item">
+            {getStorageUtilizationLabel(storage)}
+        </span>
+    </div>
+);
+
 const getCellClassName = (
     cell: CellData,
     options: {
@@ -749,15 +760,6 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                 </select>
             </div>
 
-            <div className="storage-grid__storage-meta">
-                <span className="storage-grid__storage-meta-item">
-                    {storage.rows}x{storage.columns}
-                </span>
-                <span className="storage-grid__storage-meta-item">
-                    {getStorageUtilizationLabel(storage)}
-                </span>
-            </div>
-
             <div className="storage-grid__header">
                 <div className="storage-grid__corner" />
                 {Array.from({ length: storage.columns }, (_, i) => (
@@ -833,6 +835,7 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                     </div>
                 ))}
             </div>
+            {renderStorageMeta(storage, 'storage-grid__storage-meta--after-grid')}
         </div>
     );
 
@@ -993,15 +996,6 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                     )}
                 </div>
 
-                <div className="storage-grid__storage-meta">
-                    <span className="storage-grid__storage-meta-item">
-                        {sourceStorage.rows}x{sourceStorage.columns}
-                    </span>
-                    <span className="storage-grid__storage-meta-item">
-                        {getStorageUtilizationLabel(sourceStorage)}
-                    </span>
-                </div>
-
                 {/* Message */}
                 {message && (
                     <div
@@ -1047,6 +1041,7 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                         </div>
                     ))}
                 </div>
+                {renderStorageMeta(sourceStorage, 'storage-grid__storage-meta--after-grid')}
 
                 {/* Drag overlay */}
                 <DragOverlay>


### PR DESCRIPTION
## Summary
- move the selected-storage utilisation summary below the active storage grid instead of above it
- reuse the same summary markup in browse and move modes so the chosen storage reads top-to-bottom
- keep the change in the shared storage grid component so wine and whisky layouts stay consistent

## Testing
- npm run lint -- --quiet
- CELLAR_APP_TYPE=whisky venv/bin/pytest tests/whisky/test_views.py::test_storage_grid_data_includes_utilization_stats -q --create-db
