### PR TITLE
Move bottles summary below storage content

### DIFF
--- a/tests/storage/test_storage_api.py
+++ b/tests/storage/test_storage_api.py
@@ -512,7 +512,7 @@ class TestStorageDetailView:
         r = client.get(reverse("storage-detail", kwargs={"pk": storage.pk}))
         assert r.status_code == 200
         content = r.content.decode()
-        assert content.index('id="grid-view"') < content.index(
+        assert content.index('id="storage-grid-container"') < content.index(
             "storage-detail__summary"
         )
         assert content.index("storage-detail__location") < content.index(

--- a/tests/storage/test_storage_api.py
+++ b/tests/storage/test_storage_api.py
@@ -504,6 +504,21 @@ class TestStorageDetailView:
         r = client.get(reverse("storage-detail", kwargs={"pk": storage.pk}))
         assert r.status_code == 200
 
+    def test_bottles_summary_renders_after_storage_content(
+        self, client, user, storage_factory
+    ):
+        storage = storage_factory(user=user, rows=2, columns=2)
+        client.force_login(user)
+        r = client.get(reverse("storage-detail", kwargs={"pk": storage.pk}))
+        assert r.status_code == 200
+        content = r.content.decode()
+        assert content.index('id="grid-view"') < content.index(
+            "storage-detail__summary"
+        )
+        assert content.index("storage-detail__location") < content.index(
+            "storage-detail__summary"
+        )
+
     def test_shows_wines(self, client, user, wine_factory, storage_item_factory):
         wine = wine_factory(user=user, name="Detail Wine")
         storage = user.storage_set.first()

--- a/wine_cellar/apps/storage/templates/storage_detail.html
+++ b/wine_cellar/apps/storage/templates/storage_detail.html
@@ -18,11 +18,6 @@
             </div>
             <div class="pure-u-1 pure-u-md-1 text-align-center">
                 <span class="storage-detail__location">Location: {{ storage.location }}</span>
-                {% if storage.total_slots > 0 %}
-                    <span>Bottles: {{ storage.used_slots }}/{{ storage.total_slots }}</span>
-                {% else %}
-                    <span>Bottles: {{ storage.used_slots }}</span>
-                {% endif %}
             </div>
             
             {% if storage.rows > 0 and storage.columns > 0 %}
@@ -77,6 +72,13 @@
                     {% include "includes/pagination.html" %}
                 {% else %}
                     <p>{% if CELLAR_APP_TYPE == "whisky" %}No whiskies here yet.{% else %}No wines here yet.{% endif %}</p>
+                {% endif %}
+            </div>
+            <div class="pure-u-1 pure-u-md-1 text-align-center storage-detail__summary">
+                {% if storage.total_slots > 0 %}
+                    <span>Bottles: {{ storage.used_slots }}/{{ storage.total_slots }}</span>
+                {% else %}
+                    <span>Bottles: {{ storage.used_slots }}</span>
                 {% endif %}
             </div>
         </div>

--- a/wine_cellar/assets/css/storage.css
+++ b/wine_cellar/assets/css/storage.css
@@ -35,6 +35,10 @@
   margin-right: var(--spacing-lg);
 }
 
+.storage-detail__summary {
+  margin-top: var(--spacing-md);
+}
+
 /* Storage Grid View */
 .storage-grid {
   max-width: 100%;


### PR DESCRIPTION
## Summary
- move the page-level bottles summary below the storage content instead of keeping it above the storage overview
- keep the location line at the top and add light spacing for the moved summary
- add a storage detail regression test that asserts the summary renders after the grid content

## Testing
- venv/bin/pytest tests/storage/test_storage_api.py::TestStorageDetailView::test_bottles_summary_renders_after_storage_content -q --reuse-db
