### PR TITLE
Move selected storage above overview

### DIFF
--- a/wine_cellar/assets/css/storage.css
+++ b/wine_cellar/assets/css/storage.css
@@ -80,7 +80,7 @@
 }
 
 .storage-grid__overview {
-  margin-bottom: var(--spacing-lg);
+  margin-top: var(--spacing-lg);
   padding: var(--spacing-md);
   background-color: var(--gray-100);
   border-radius: var(--border-radius);

--- a/wine_cellar/react/storage_grid.tsx
+++ b/wine_cellar/react/storage_grid.tsx
@@ -967,8 +967,6 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
             onDragEnd={handleDragEnd}
         >
             <div className="storage-grid">
-                {renderOverview()}
-
                 {/* Controls */}
                 <div className="storage-grid__controls">
                     <label htmlFor="storage-select">{translated.storage}:</label>
@@ -1058,6 +1056,8 @@ const StorageGrid: React.FC<StorageGridProps> = ({ initialStorageId }) => {
                     <p><i className="fa-solid fa-hand-pointer" /> {translated.tapToSeeDetails}</p>
                     <p><i className="fa-solid fa-hand-back-fist" /> {translated.dragToMove}</p>
                 </div>
+
+                {renderOverview()}
             </div>
         </DndContext>
     );


### PR DESCRIPTION
## Summary
- render the selected storage grid before the storage overview cards
- move the overview section below the active grid so the chosen storage appears first
- adjust overview spacing for the new order

## Testing
- npm run lint -- --quiet
