### PR TITLE
Hide taste descriptions behind an option

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -1269,6 +1269,44 @@ class TestDrinkRecordDeleteView:
 
 @pytest.mark.django_db
 class TestTastingWheel:
+    def test_drink_record_create_hides_taste_descriptors_by_default(
+        self, client, user, wine_factory
+    ):
+        wine = wine_factory(user=user)
+        client.force_login(user)
+
+        response = client.get(reverse("drink-record-add", kwargs={"pk": wine.pk}))
+        html = response.content.decode()
+
+        assert response.status_code == HTTPStatus.OK
+        assert '<details id="taste-descriptors-toggle">' in html
+        assert '<details id="taste-descriptors-toggle" open>' not in html
+
+    def test_drink_record_edit_shows_taste_descriptors_when_present(
+        self, client, user, wine_factory
+    ):
+        from datetime import date
+
+        from wine_cellar.apps.wine.models import DrinkRecord
+
+        wine = wine_factory(user=user)
+        household = user.user_settings.active_household
+        record = DrinkRecord.objects.create(
+            wine=wine,
+            user=user,
+            household=household,
+            date_consumed=date.today(),
+            taste_descriptors=["Apple"],
+        )
+        client.force_login(user)
+
+        response = client.get(reverse("drink-record-edit", kwargs={"pk": record.pk}))
+
+        assert response.status_code == HTTPStatus.OK
+        assert (
+            '<details id="taste-descriptors-toggle" open>' in response.content.decode()
+        )
+
     def test_drink_record_create_with_taste_descriptors(
         self, client, user, wine_factory
     ):

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -1892,6 +1892,46 @@ def test_whisky_check_duplicate_no_cross_household(
 
 
 @pytest.mark.django_db
+def test_whisky_drink_record_create_hides_taste_descriptors_by_default(
+    client, user, whisky_factory
+):
+    whisky = whisky_factory(user=user)
+    client.force_login(user)
+
+    response = client.get(reverse("drink-record-add", kwargs={"pk": whisky.pk}))
+    html = response.content.decode()
+
+    assert response.status_code == HTTPStatus.OK
+    assert '<details id="taste-descriptors-toggle">' in html
+    assert '<details id="taste-descriptors-toggle" open>' not in html
+
+
+@pytest.mark.django_db
+def test_whisky_drink_record_edit_shows_taste_descriptors_when_present(
+    client, user, whisky_factory
+):
+    from datetime import date
+
+    from wine_cellar.apps.whisky.models import WhiskyDrinkRecord
+
+    whisky = whisky_factory(user=user)
+    household = user.user_settings.active_household
+    record = WhiskyDrinkRecord.objects.create(
+        whisky=whisky,
+        user=user,
+        household=household,
+        date_consumed=date.today(),
+        taste_descriptors=["Smoky"],
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("drink-record-edit", kwargs={"pk": record.pk}))
+
+    assert response.status_code == HTTPStatus.OK
+    assert '<details id="taste-descriptors-toggle" open>' in response.content.decode()
+
+
+@pytest.mark.django_db
 def test_whisky_drink_record_create_with_taste_descriptors(
     client, user, whisky_factory
 ):

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -425,14 +425,8 @@ class BaseReorderReminderCreateView(RequireMemberMixin, FormView):
         beverage = get_object_or_404(
             self.beverage_model, pk=self.kwargs["pk"], household=household
         )
-        form = context.get("form")
         context[self.beverage_fk_name] = beverage
         context["beverage"] = beverage
-        context["show_taste_descriptors"] = bool(
-            form
-            and "taste_descriptors" in form.fields
-            and _has_selected_taste_descriptors(form["taste_descriptors"].value())
-        )
         return context
 
     def form_valid(self, form):

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -39,6 +39,13 @@ def _parse_taste_descriptors(descriptors_str):
         return []
 
 
+def _has_selected_taste_descriptors(descriptors):
+    """Return whether the form currently has any selected taste descriptors."""
+    if isinstance(descriptors, list):
+        return bool(descriptors)
+    return bool(_parse_taste_descriptors(descriptors))
+
+
 # --- Wishlist views ---
 
 
@@ -269,10 +276,16 @@ class BaseDrinkRecordEditView(RequireMemberMixin, FormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         record = self.get_object()
+        form = context.get("form")
         context["record"] = record
         beverage = getattr(record, self.beverage_fk_name)
         context[self.beverage_fk_name] = beverage
         context["beverage"] = beverage
+        context["show_taste_descriptors"] = bool(
+            form
+            and "taste_descriptors" in form.fields
+            and _has_selected_taste_descriptors(form["taste_descriptors"].value())
+        )
         return context
 
     def form_valid(self, form):
@@ -412,8 +425,14 @@ class BaseReorderReminderCreateView(RequireMemberMixin, FormView):
         beverage = get_object_or_404(
             self.beverage_model, pk=self.kwargs["pk"], household=household
         )
+        form = context.get("form")
         context[self.beverage_fk_name] = beverage
         context["beverage"] = beverage
+        context["show_taste_descriptors"] = bool(
+            form
+            and "taste_descriptors" in form.fields
+            and _has_selected_taste_descriptors(form["taste_descriptors"].value())
+        )
         return context
 
     def form_valid(self, form):

--- a/wine_cellar/templates/core/drink_record_create.html
+++ b/wine_cellar/templates/core/drink_record_create.html
@@ -63,11 +63,15 @@
                 {% csrf_token %}
                 {% for field in form %}
                     {% if field.name == 'taste_descriptors' %}
-                        <div class="form-group">
-                            <label id="taste-wheel-label">{{ field.label }}</label>
-                            <div id="taste-wheel-container" aria-labelledby="taste-wheel-label"></div>
-                            {{ field }}
-                        </div>
+                        <details id="taste-descriptors-toggle"{% if show_taste_descriptors %} open{% endif %}>
+                            <summary>Taste descriptors</summary>
+                            <div class="form-group">
+                                <label id="taste-wheel-label">{{ field.label }}</label>
+                                {% if field.help_text %}<p class="form-hint">{{ field.help_text }}</p>{% endif %}
+                                <div id="taste-wheel-container" aria-labelledby="taste-wheel-label"></div>
+                                {{ field }}
+                            </div>
+                        </details>
                     {% else %}
                         {% include 'forms/form_field.html' %}
                     {% endif %}

--- a/wine_cellar/templates/core/drink_record_edit.html
+++ b/wine_cellar/templates/core/drink_record_edit.html
@@ -24,11 +24,17 @@
                 {% csrf_token %}
                 {% include 'forms/form_field.html' with field=form.date_consumed %}
                 {% include 'forms/form_field.html' with field=form.tasting_notes %}
-                <div class="form-group">
-                    <label id="taste-wheel-label">Taste Descriptors</label>
-                    <div id="taste-wheel-container" aria-labelledby="taste-wheel-label"></div>
-                    {{ form.taste_descriptors }}
-                </div>
+                <details id="taste-descriptors-toggle"{% if show_taste_descriptors %} open{% endif %}>
+                    <summary>Taste descriptors</summary>
+                    <div class="form-group">
+                        <label id="taste-wheel-label">{{ form.taste_descriptors.label }}</label>
+                        {% if form.taste_descriptors.help_text %}
+                            <p class="form-hint">{{ form.taste_descriptors.help_text }}</p>
+                        {% endif %}
+                        <div id="taste-wheel-container" aria-labelledby="taste-wheel-label"></div>
+                        {{ form.taste_descriptors }}
+                    </div>
+                </details>
                 {% include 'forms/form_field.html' with field=form.rating %}
                 {% include 'forms/form_field.html' with field=form.shared_with %}
                 {% include 'forms/form_field.html' with field=form.occasion %}


### PR DESCRIPTION
## Summary
- hide taste descriptors behind a collapsed option in shared drink record forms
- auto-open the section when an existing drink record already has saved descriptors
- add wine and whisky regression coverage for the toggle behavior

## Testing
- make pytest
- black --check wine_cellar tests
- isort --diff -c wine_cellar tests
- flake8 wine_cellar tests --exclude migrations,settings
- docker run --rm -v "$(pwd)":/app -v /app/node_modules -w /app node:20-slim sh -lc "npm ci --no-audit --no-fund >/dev/null && npm run lint"
- python manage.py makemigrations --dry-run --check --noinput

Refs #219