### PR TITLE
Fix wine drink record delete confirmation page

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -1230,6 +1230,23 @@ class TestDrinkRecordEditView:
 
 @pytest.mark.django_db
 class TestDrinkRecordDeleteView:
+    def test_get_renders_confirmation_page(self, client, user, wine_factory):
+        from datetime import date
+
+        from wine_cellar.apps.wine.models import DrinkRecord
+
+        wine = wine_factory(user=user)
+        household = user.user_settings.active_household
+        record = DrinkRecord.objects.create(
+            wine=wine, user=user, household=household, date_consumed=date.today()
+        )
+        client.force_login(user)
+
+        r = client.get(reverse("drink-record-delete", kwargs={"pk": record.pk}))
+
+        assert r.status_code == HTTPStatus.OK
+        assert "Delete Drink Record" in r.content.decode()
+
     def test_post_deletes_record(self, client, user, wine_factory):
         from datetime import date
 

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -1991,3 +1991,22 @@ def test_whisky_drink_record_edit_with_taste_descriptors(client, user, whisky_fa
     assert r.status_code == HTTPStatus.FOUND
     record.refresh_from_db()
     assert record.taste_descriptors == new_descriptors
+
+
+@pytest.mark.django_db
+def test_whisky_drink_record_delete_confirmation_renders(client, user, whisky_factory):
+    from datetime import date
+
+    from wine_cellar.apps.whisky.models import WhiskyDrinkRecord
+
+    whisky = whisky_factory(user=user)
+    household = user.user_settings.active_household
+    record = WhiskyDrinkRecord.objects.create(
+        whisky=whisky, user=user, household=household, date_consumed=date.today()
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("drink-record-delete", kwargs={"pk": record.pk}))
+
+    assert response.status_code == HTTPStatus.OK
+    assert "Delete Drink Record" in response.content.decode()

--- a/wine_cellar/templates/drink_record_confirm_delete.html
+++ b/wine_cellar/templates/drink_record_confirm_delete.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+    Delete Drink Record
+{% endblock title %}
+{% block header %}
+    <h1 class="header__title">Delete Drink Record</h1>
+{% endblock header %}
+{% block content %}
+    <div class="pure-g">
+        <div class="pure-u-1 pure-u-lg-1-3 m-auto">
+            <form method="post"
+                  enctype="multipart/form-data"
+                  class="pure-form pure-form-stacked wine-form">
+                {% csrf_token %}
+                <p>
+                    Are you sure you want to delete this drink record? This action cannot be undone.
+                </p>
+                <div class="pure-controls">
+                    <div class="pure-g">
+                        <div class="pure-u-1 pure-u-sm-1-2">
+                            <a href="{% url 'drink-history' %}"
+                               class="pure-button button__primary">Cancel</a>
+                        </div>
+                        <div id="save_button_container" class="pure-u-1 pure-u-sm-1-2">
+                            <button type="submit" name="save" class="pure-button button__secondary">Delete</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
## Summary
- add the missing wine drink record delete confirmation template
- add GET coverage for wine delete confirmation rendering
- add matching whisky delete confirmation coverage

## Validation
- venv/bin/py.test tests/test_core_views.py::TestDrinkRecordDeleteView --reuse-db
- CELLAR_APP_TYPE=whisky venv/bin/py.test tests/whisky/test_views.py::test_whisky_drink_record_delete_confirmation_renders --reuse-db
- venv/bin/black --check tests/test_core_views.py tests/whisky/test_views.py
- venv/bin/isort --diff -c tests/test_core_views.py tests/whisky/test_views.py
- venv/bin/flake8 tests/test_core_views.py tests/whisky/test_views.py