### PR TITLE
Add zoomable photo viewer on detail pages

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -465,6 +465,22 @@ class TestWineDetailView:
         assert "Producer profile" in content
         assert 'href="https://example.com/producer"' in content
 
+    def test_detail_view_renders_photo_viewer_controls(
+        self, client, user, wine_factory, wine_image_factory, clear_image_folder
+    ):
+        wine = wine_factory(user=user, name="Photo Wine")
+        wine_image_factory(user=user, wine=wine, image_type="LF")
+        client.force_login(user)
+
+        response = client.get(reverse("wine-detail", kwargs={"pk": wine.pk}))
+
+        assert response.status_code == HTTPStatus.OK
+        content = response.content.decode()
+        assert 'data-image-viewer-open' in content
+        assert 'id="beverage-image-viewer"' in content
+        assert 'data-image-viewer-zoom-in' in content
+        assert "View Photos" in content
+
     def test_can_add_price_history(self, client, user, wine_factory, source_factory):
         household = user.user_settings.active_household
         wine = wine_factory(user=user, name="Tracked Wine")

--- a/tests/test_wine_model.py
+++ b/tests/test_wine_model.py
@@ -176,11 +176,12 @@ def test_image_properties_use_prefetch_cache(
     qs = Wine.objects.prefetch_related("wineimage_set").filter(pk=wine.pk)
     prefetched_wine = qs.first()
 
-    # Accessing all three image properties should use the prefetch cache (0 extra)
+    # Accessing all image properties should use the prefetch cache (0 extra)
     with CaptureQueriesContext(connection) as ctx:
         _ = prefetched_wine.image
         _ = prefetched_wine.image_thumbnail
         _ = prefetched_wine.image_thumbnails
+        _ = prefetched_wine.detail_image_urls
     assert len(ctx.captured_queries) == 0, (
         f"Expected 0 queries but got {len(ctx.captured_queries)}: "
         f"{[q['sql'] for q in ctx.captured_queries]}"

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -948,6 +948,9 @@ def test_whisky_detail_shows_carousel_controls_for_multiple_images(
     assert 'class="image-controls"' in content
     assert 'class="wine-prev"' in content
     assert 'class="wine-next"' in content
+    assert 'id="beverage-image-viewer"' in content
+    assert 'data-image-viewer-zoom-in' in content
+    assert "View Photos" in content
 
 
 @pytest.mark.django_db

--- a/wine_cellar/apps/whisky/models.py
+++ b/wine_cellar/apps/whisky/models.py
@@ -550,6 +550,25 @@ class Whisky(UserContentModel):
         return result
 
     @property
+    def detail_image_urls(self):
+        """Return the full-size image URLs for the detail-page viewer."""
+        image_type_order = {
+            WhiskyImage.ImageType.LABEL_FRONT: 0,
+            WhiskyImage.ImageType.LABEL_BACK: 1,
+        }
+        return [
+            versioned_media_url(image.image) or image.image.url
+            for image in sorted(
+                self.images.all(),
+                key=lambda image: (
+                    0 if image.is_primary else 1,
+                    image_type_order.get(image.image_type, len(image_type_order)),
+                    image.pk,
+                ),
+            )
+        ]
+
+    @property
     def display_type(self):
         return self.get_whisky_type_display()
 

--- a/wine_cellar/apps/whisky/models.py
+++ b/wine_cellar/apps/whisky/models.py
@@ -550,7 +550,7 @@ class Whisky(UserContentModel):
         return result
 
     @property
-    def detail_image_urls(self):
+    def detail_image_urls(self) -> list[str]:
         """Return the full-size image URLs for the detail-page viewer."""
         image_type_order = {
             WhiskyImage.ImageType.LABEL_FRONT: 0,

--- a/wine_cellar/apps/whisky/templates/whisky/whisky_detail.html
+++ b/wine_cellar/apps/whisky/templates/whisky/whisky_detail.html
@@ -21,42 +21,8 @@
                 </div>
             </div>
             <div class="pure-u-1 pure-u-md-1-2">
-                {% if whisky.image_thumbnail %}
-                    {% with images=whisky.all_images %}
-                        <div class="wine-detail__image-wrapper"
-                             data-images='[{% for img in images %}"{{ img }}"{% if not forloop.last %},{% endif %}{% endfor %}]'>
-                            <div class="image wine-detail__image" id="wine-image-wrapper">
-                                <img id="wine-image"
-                                     src="{{ whisky.image_thumbnail }}"
-                                     loading="lazy"
-                                     height="225"
-                                     width="auto"
-                                     alt="Picture of a whisky bottle">
-                            </div>
-                            {% if images|length > 1 %}
-                                <div class="image-controls"
-                                     role="group"
-                                     aria-label="Image carousel controls">
-                                    <button type="button"
-                                            class="wine-prev"
-                                            aria-label="Previous image"
-                                            title="Previous image">«</button>
-                                    <button type="button"
-                                            class="wine-next"
-                                            aria-label="Next image"
-                                            title="Next image">»</button>
-                                </div>
-                            {% endif %}
-                        </div>
-                    {% endwith %}
-                    <div class="wine-detail__image-actions">
-                        <a href="{% url 'whisky-images' whisky.pk %}" class="pure-button button__neutral">
-                            <i class="fa-solid fa-crop"></i> Edit Images
-                        </a>
-                    </div>
-                {% else %}
-                    <div>No image</div>
-                {% endif %}
+                {% url 'whisky-images' whisky.pk as image_edit_url %}
+                {% include "includes/detail_image_viewer.html" with beverage=whisky preview_image=whisky.image_thumbnail detail_images=whisky.detail_image_urls edit_url=image_edit_url image_alt="Picture of a whisky bottle" %}
             </div>
             <div class="pure-u-1 pure-u-md-1-2">
                 <table class="wine-detail__table">

--- a/wine_cellar/apps/wine/models.py
+++ b/wine_cellar/apps/wine/models.py
@@ -551,6 +551,25 @@ class Wine(UserContentModel):
         return result
 
     @property
+    def detail_image_urls(self) -> list[str]:
+        """Return the full-size image URLs for the detail-page viewer."""
+        image_type_order = {
+            ImageType.LABEL_FRONT: 0,
+            ImageType.LABEL_BACK: 1,
+        }
+        return [
+            _versioned_media_url(image.image) or image.image.url
+            for image in sorted(
+                self._cached_images(),
+                key=lambda image: (
+                    0 if image.is_primary else 1,
+                    image_type_order.get(image.image_type, len(image_type_order)),
+                    image.pk,
+                ),
+            )
+        ]
+
+    @property
     def country_name(self):
         return pycountry.countries.get(alpha_2=self.country).name
 

--- a/wine_cellar/apps/wine/templates/wine_detail.html
+++ b/wine_cellar/apps/wine/templates/wine_detail.html
@@ -21,40 +21,8 @@
                 </div>
             </div>
             <div class="pure-u-1 pure-u-md-1-2">
-                {% if wine.image_thumbnail %}
-                    <div class="wine-detail__image-wrapper"
-                         data-images='[{% for img in wine.image_thumbnails %}"{{ img }}"{% if not forloop.last %},{% endif %}{% endfor %}]'>
-                        <div class="image wine-detail__image" id="wine-image-wrapper">
-                            <img id="wine-image"
-                                 src="{{ wine.image_thumbnail }}"
-                                 loading="lazy"
-                                 height="225"
-                                 width="auto"
-                                 alt="Picture of a wine bottle">
-                        </div>
-                        {% if wine.image_thumbnails|length > 1 %}
-                            <div class="image-controls"
-                                 role="group"
-                                 aria-label="Image carousel controls">
-                                <button type="button"
-                                        class="wine-prev"
-                                        aria-label="Previous image"
-                                        title="Previous image">«</button>
-                                <button type="button"
-                                        class="wine-next"
-                                        aria-label="Next image"
-                                        title="Next image">»</button>
-                            </div>
-                        {% endif %}
-                    </div>
-                    <div class="wine-detail__image-actions">
-                        <a href="{% url 'wine-images' wine.pk %}" class="pure-button button__neutral">
-                            <i class="fa-solid fa-crop"></i> Edit Images
-                        </a>
-                    </div>
-                {% else %}
-                    <div>No image</div>
-                {% endif %}
+                {% url 'wine-images' wine.pk as image_edit_url %}
+                {% include "includes/detail_image_viewer.html" with beverage=wine preview_image=wine.image_thumbnail detail_images=wine.detail_image_urls edit_url=image_edit_url image_alt="Picture of a wine bottle" %}
             </div>
             <div class="pure-u-1 pure-u-md-1-2">
                 <table class="wine-detail__table">

--- a/wine_cellar/assets/css/detail.css
+++ b/wine_cellar/assets/css/detail.css
@@ -88,6 +88,12 @@
   }
 }
 
+.wine-detail__preview-image[hidden],
+.image-viewer__image[hidden],
+.image-viewer__open-link[hidden] {
+  display: none;
+}
+
 .wine-detail__image-actions {
   display: flex;
   justify-content: center;

--- a/wine_cellar/assets/css/detail.css
+++ b/wine_cellar/assets/css/detail.css
@@ -49,6 +49,20 @@
   }
 }
 
+.wine-detail__image-button {
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: zoom-in;
+
+  &:focus {
+    outline: 3px solid rgba(1, 150, 3, 0.3);
+    outline-offset: 4px;
+    border-radius: var(--border-radius-lg);
+  }
+}
+
 .wine-detail__image {
   height: 237px;
   width: 158px;
@@ -71,6 +85,180 @@
     height: auto;
     border-radius: var(--border-radius);
     object-fit: contain;
+  }
+}
+
+.wine-detail__image-actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-lg);
+}
+
+.image-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  padding: var(--spacing-md);
+  box-sizing: border-box;
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.image-viewer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.92);
+}
+
+.image-viewer__sheet {
+  position: relative;
+  z-index: 1;
+  height: 100%;
+  max-width: 70rem;
+  margin: 0 auto;
+  background: rgba(17, 24, 39, 0.98);
+  color: var(--white);
+  border-radius: var(--border-radius-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: var(--container-box-shadow-lg);
+}
+
+.image-viewer__header,
+.image-viewer__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  flex-wrap: wrap;
+}
+
+.image-viewer__header {
+  padding-top: max(var(--spacing-md), env(safe-area-inset-top));
+}
+
+.image-viewer__title,
+.image-viewer__meta {
+  margin: 0;
+}
+
+.image-viewer__title {
+  font-size: var(--font-lg);
+  font-weight: 600;
+}
+
+.image-viewer__meta {
+  color: var(--gray-300);
+  font-size: var(--font-sm);
+}
+
+.image-viewer__control-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.image-viewer__icon-button,
+.image-viewer__zoom-reset {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 var(--spacing-sm);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: var(--border-radius-sm);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--white);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  cursor: pointer;
+}
+
+.image-viewer__zoom-reset {
+  min-width: 4.5rem;
+  font-weight: 600;
+}
+
+.image-viewer__icon-button:hover,
+.image-viewer__zoom-reset:hover,
+.image-viewer__open-link:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.image-viewer__icon-button:focus,
+.image-viewer__zoom-reset:focus,
+.image-viewer__open-link:focus {
+  outline: 3px solid rgba(1, 150, 3, 0.4);
+  outline-offset: 2px;
+}
+
+.image-viewer__icon-button:disabled,
+.image-viewer__zoom-reset:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.image-viewer__open-link {
+  min-height: 44px;
+  padding: 0 var(--spacing-md);
+  border-radius: var(--border-radius-sm);
+  color: var(--white);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.image-viewer__stage {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.image-viewer__canvas {
+  min-width: 100%;
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-md);
+  box-sizing: border-box;
+}
+
+.image-viewer__image {
+  display: block;
+  max-width: none;
+  width: auto;
+  height: auto;
+  border-radius: var(--border-radius);
+  background: var(--white);
+  box-shadow: var(--container-box-shadow);
+}
+
+@media screen and (max-width: 48em) {
+  .image-viewer {
+    padding: 0;
+  }
+
+  .image-viewer__sheet {
+    border-radius: 0;
+  }
+
+  .image-viewer__toolbar {
+    justify-content: center;
+  }
+
+  .image-viewer__open-link {
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/wine_cellar/assets/js/wine_carousel.ts
+++ b/wine_cellar/assets/js/wine_carousel.ts
@@ -1,12 +1,11 @@
 document.addEventListener("DOMContentLoaded", function () {
     const wrapper = document.querySelector(".wine-detail__image-wrapper") as HTMLElement | null;
-    const previewImage = document.getElementById("wine-image") as HTMLImageElement | null;
-    const imageData = document.getElementById("beverage-detail-images");
+    if (!wrapper) return;
 
-    if (!wrapper || !previewImage || !imageData?.textContent) return;
-
-    const images = JSON.parse(imageData.textContent) as string[];
-    if (!Array.isArray(images) || images.length === 0) return;
+    const previewImages = Array.from(
+        wrapper.querySelectorAll("[data-preview-image]"),
+    ) as HTMLImageElement[];
+    if (previewImages.length === 0) return;
 
     const prevBtn = wrapper.querySelector(".wine-prev") as HTMLButtonElement | null;
     const nextBtn = wrapper.querySelector(".wine-next") as HTMLButtonElement | null;
@@ -15,15 +14,15 @@ document.addEventListener("DOMContentLoaded", function () {
     const viewerStage = document.getElementById(
         "beverage-image-viewer-stage",
     ) as HTMLElement | null;
-    const viewerImage = document.getElementById(
-        "beverage-image-viewer-image",
-    ) as HTMLImageElement | null;
+    const viewerImages = Array.from(
+        viewer?.querySelectorAll("[data-image-viewer-image]") ?? [],
+    ) as HTMLImageElement[];
+    const viewerLinks = Array.from(
+        viewer?.querySelectorAll("[data-image-viewer-link]") ?? [],
+    ) as HTMLAnchorElement[];
     const viewerCount = document.getElementById(
         "beverage-image-viewer-count",
     ) as HTMLElement | null;
-    const viewerLink = document.getElementById(
-        "beverage-image-viewer-link",
-    ) as HTMLAnchorElement | null;
     const viewerPrev = viewer?.querySelector(
         "[data-image-viewer-prev]",
     ) as HTMLButtonElement | null;
@@ -49,27 +48,14 @@ document.addEventListener("DOMContentLoaded", function () {
     const MAX_ZOOM = 4;
     const ZOOM_STEP = 0.5;
 
-    function safeMediaUrl(url: string): string | null {
-        if (typeof url !== "string" || url.trim() === "") {
-            return null;
-        }
-
-        try {
-            const parsed = new URL(url, window.location.origin);
-            if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-                return url;
-            }
-        } catch {
-            return null;
-        }
-
-        return null;
+    function currentViewerImage(): HTMLImageElement | null {
+        return viewerImages[index] ?? null;
     }
 
     function setViewerNavigationState() {
         if (!viewerPrev || !viewerNext) return;
 
-        const disabled = images.length <= 1;
+        const disabled = previewImages.length <= 1;
         viewerPrev.disabled = disabled;
         viewerNext.disabled = disabled;
     }
@@ -84,6 +70,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     function applyZoom(resetScroll = false) {
+        const viewerImage = currentViewerImage();
         if (!viewerStage || !viewerImage || !viewerImage.naturalWidth || !viewerImage.naturalHeight) {
             setZoomState();
             return;
@@ -109,28 +96,23 @@ document.addEventListener("DOMContentLoaded", function () {
         setZoomState();
     }
 
-    function setIndex(nextIndex: number, skipPreview = false) {
-        index = (nextIndex + images.length) % images.length;
-        const safeUrl = safeMediaUrl(images[index]);
+    function setIndex(nextIndex: number) {
+        index = (nextIndex + previewImages.length) % previewImages.length;
 
-        if (!skipPreview && safeUrl) {
-            previewImage.src = safeUrl;
-        }
+        previewImages.forEach((image, imageIndex) => {
+            image.hidden = imageIndex !== index;
+        });
 
-        if (viewerImage && safeUrl) {
-            viewerImage.src = safeUrl;
-        }
+        viewerImages.forEach((image, imageIndex) => {
+            image.hidden = imageIndex !== index;
+        });
+
+        viewerLinks.forEach((link, linkIndex) => {
+            link.hidden = linkIndex !== index;
+        });
 
         if (viewerCount) {
-            viewerCount.textContent = `Photo ${index + 1} of ${images.length}`;
-        }
-
-        if (viewerLink) {
-            if (safeUrl) {
-                viewerLink.href = safeUrl;
-            } else {
-                viewerLink.removeAttribute("href");
-            }
+            viewerCount.textContent = `Photo ${index + 1} of ${previewImages.length}`;
         }
     }
 
@@ -206,13 +188,19 @@ document.addEventListener("DOMContentLoaded", function () {
         button.addEventListener("click", closeViewer);
     });
 
-    viewerImage?.addEventListener("load", () => {
-        applyZoom(true);
+    viewerImages.forEach((image) => {
+        image.addEventListener("load", () => {
+            if (!image.hidden) {
+                applyZoom(true);
+            }
+        });
     });
 
-    viewerImage?.addEventListener("dblclick", () => {
-        zoom = zoom === 1 ? 2 : 1;
-        applyZoom();
+    viewerImages.forEach((image) => {
+        image.addEventListener("dblclick", () => {
+            zoom = zoom === 1 ? 2 : 1;
+            applyZoom();
+        });
     });
 
     window.addEventListener("resize", () => {
@@ -257,6 +245,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     setViewerNavigationState();
-    setIndex(0, true);
+    setIndex(0);
     setZoomState();
 });

--- a/wine_cellar/assets/js/wine_carousel.ts
+++ b/wine_cellar/assets/js/wine_carousel.ts
@@ -43,10 +43,26 @@ document.addEventListener("DOMContentLoaded", function () {
 
     let index = 0;
     let zoom = 1;
+    let lastFocusedBeforeOpen: HTMLElement | null = null;
 
     const MIN_ZOOM = 1;
     const MAX_ZOOM = 4;
     const ZOOM_STEP = 0.5;
+
+    /** Return the URL only if it is a safe http/https or root-relative URL. */
+    function safeMediaUrl(url: string): string {
+        if (typeof url !== "string") return "";
+        if (url.startsWith("/")) return url;
+        try {
+            const parsed = new URL(url);
+            if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+                return url;
+            }
+        } catch {
+            // not a valid absolute URL
+        }
+        return "";
+    }
 
     function setViewerNavigationState() {
         if (!viewerPrev || !viewerNext) return;
@@ -91,13 +107,14 @@ document.addEventListener("DOMContentLoaded", function () {
         setZoomState();
     }
 
-    function setIndex(nextIndex: number) {
+    function setIndex(nextIndex: number, skipPreview = false) {
         index = (nextIndex + images.length) % images.length;
-        previewImage.src = images[index];
+        if (!skipPreview && previewImage) {
+            previewImage.src = safeMediaUrl(images[index]);
+        }
 
         if (viewerImage) {
-            viewerImage.src = images[index];
-            viewerImage.alt = `Photo ${index + 1}`;
+            viewerImage.src = safeMediaUrl(images[index]);
         }
 
         if (viewerCount) {
@@ -105,7 +122,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }
 
         if (viewerLink) {
-            viewerLink.href = images[index];
+            viewerLink.href = safeMediaUrl(images[index]);
         }
     }
 
@@ -122,6 +139,7 @@ document.addEventListener("DOMContentLoaded", function () {
     function openViewer() {
         if (!viewer) return;
 
+        lastFocusedBeforeOpen = document.activeElement as HTMLElement | null;
         viewer.hidden = false;
         document.body.style.overflow = "hidden";
         setIndex(index);
@@ -134,6 +152,8 @@ document.addEventListener("DOMContentLoaded", function () {
 
         viewer.hidden = true;
         document.body.style.overflow = "";
+        lastFocusedBeforeOpen?.focus();
+        lastFocusedBeforeOpen = null;
     }
 
     if (prevBtn) {
@@ -227,6 +247,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     setViewerNavigationState();
-    setIndex(0);
+    setIndex(0, true);  // initialise viewer state without overwriting server-rendered thumbnail
     setZoomState();
 });

--- a/wine_cellar/assets/js/wine_carousel.ts
+++ b/wine_cellar/assets/js/wine_carousel.ts
@@ -49,19 +49,21 @@ document.addEventListener("DOMContentLoaded", function () {
     const MAX_ZOOM = 4;
     const ZOOM_STEP = 0.5;
 
-    /** Return the URL only if it is a safe http/https or root-relative URL. */
-    function safeMediaUrl(url: string): string {
-        if (typeof url !== "string") return "";
-        if (url.startsWith("/")) return url;
+    function safeMediaUrl(url: string): string | null {
+        if (typeof url !== "string" || url.trim() === "") {
+            return null;
+        }
+
         try {
-            const parsed = new URL(url);
-            if (parsed.protocol === "https:" || parsed.protocol === "http:") {
+            const parsed = new URL(url, window.location.origin);
+            if (parsed.protocol === "http:" || parsed.protocol === "https:") {
                 return url;
             }
         } catch {
-            // not a valid absolute URL
+            return null;
         }
-        return "";
+
+        return null;
     }
 
     function setViewerNavigationState() {
@@ -109,12 +111,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
     function setIndex(nextIndex: number, skipPreview = false) {
         index = (nextIndex + images.length) % images.length;
-        if (!skipPreview && previewImage) {
-            previewImage.src = safeMediaUrl(images[index]);
+        const safeUrl = safeMediaUrl(images[index]);
+
+        if (!skipPreview && safeUrl) {
+            previewImage.src = safeUrl;
         }
 
-        if (viewerImage) {
-            viewerImage.src = safeMediaUrl(images[index]);
+        if (viewerImage && safeUrl) {
+            viewerImage.src = safeUrl;
         }
 
         if (viewerCount) {
@@ -122,7 +126,11 @@ document.addEventListener("DOMContentLoaded", function () {
         }
 
         if (viewerLink) {
-            viewerLink.href = safeMediaUrl(images[index]);
+            if (safeUrl) {
+                viewerLink.href = safeUrl;
+            } else {
+                viewerLink.removeAttribute("href");
+            }
         }
     }
 
@@ -152,7 +160,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
         viewer.hidden = true;
         document.body.style.overflow = "";
-        lastFocusedBeforeOpen?.focus();
+        if (lastFocusedBeforeOpen?.isConnected) {
+            lastFocusedBeforeOpen.focus();
+        }
         lastFocusedBeforeOpen = null;
     }
 
@@ -247,6 +257,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     setViewerNavigationState();
-    setIndex(0, true);  // initialise viewer state without overwriting server-rendered thumbnail
+    setIndex(0, true);
     setZoomState();
 });

--- a/wine_cellar/assets/js/wine_carousel.ts
+++ b/wine_cellar/assets/js/wine_carousel.ts
@@ -1,29 +1,232 @@
 document.addEventListener("DOMContentLoaded", function () {
-    const wrapper = document.querySelector(".wine-detail__image-wrapper") as HTMLElement;
-    if (!wrapper) return;
+    const wrapper = document.querySelector(".wine-detail__image-wrapper") as HTMLElement | null;
+    const previewImage = document.getElementById("wine-image") as HTMLImageElement | null;
+    const imageData = document.getElementById("beverage-detail-images");
 
-    const images = JSON.parse(wrapper.dataset.images || '[]');
-    if (images.length <= 1) return;
+    if (!wrapper || !previewImage || !imageData?.textContent) return;
+
+    const images = JSON.parse(imageData.textContent) as string[];
+    if (!Array.isArray(images) || images.length === 0) return;
+
+    const prevBtn = wrapper.querySelector(".wine-prev") as HTMLButtonElement | null;
+    const nextBtn = wrapper.querySelector(".wine-next") as HTMLButtonElement | null;
+    const openButtons = document.querySelectorAll("[data-image-viewer-open]");
+    const viewer = document.getElementById("beverage-image-viewer") as HTMLElement | null;
+    const viewerStage = document.getElementById(
+        "beverage-image-viewer-stage",
+    ) as HTMLElement | null;
+    const viewerImage = document.getElementById(
+        "beverage-image-viewer-image",
+    ) as HTMLImageElement | null;
+    const viewerCount = document.getElementById(
+        "beverage-image-viewer-count",
+    ) as HTMLElement | null;
+    const viewerLink = document.getElementById(
+        "beverage-image-viewer-link",
+    ) as HTMLAnchorElement | null;
+    const viewerPrev = viewer?.querySelector(
+        "[data-image-viewer-prev]",
+    ) as HTMLButtonElement | null;
+    const viewerNext = viewer?.querySelector(
+        "[data-image-viewer-next]",
+    ) as HTMLButtonElement | null;
+    const zoomOutButton = viewer?.querySelector(
+        "[data-image-viewer-zoom-out]",
+    ) as HTMLButtonElement | null;
+    const zoomInButton = viewer?.querySelector(
+        "[data-image-viewer-zoom-in]",
+    ) as HTMLButtonElement | null;
+    const zoomResetButton = viewer?.querySelector(
+        "[data-image-viewer-reset]",
+    ) as HTMLButtonElement | null;
+    const closeButtons = viewer?.querySelectorAll("[data-image-viewer-close]");
 
     let index = 0;
+    let zoom = 1;
 
-    const imgEl = document.getElementById("wine-image") as HTMLImageElement;
-    const prevBtn = wrapper.querySelector(".wine-prev") as HTMLButtonElement;
-    const nextBtn = wrapper.querySelector(".wine-next") as HTMLButtonElement;
+    const MIN_ZOOM = 1;
+    const MAX_ZOOM = 4;
+    const ZOOM_STEP = 0.5;
 
-    if (!imgEl || !prevBtn || !nextBtn) return;
+    function setViewerNavigationState() {
+        if (!viewerPrev || !viewerNext) return;
 
-    function updateImage() {
-        imgEl.src = images[index];
+        const disabled = images.length <= 1;
+        viewerPrev.disabled = disabled;
+        viewerNext.disabled = disabled;
     }
 
-    prevBtn.addEventListener("click", () => {
-        index = (index - 1 + images.length) % images.length;
-        updateImage();
+    function setZoomState() {
+        if (!zoomOutButton || !zoomInButton || !zoomResetButton) return;
+
+        zoomOutButton.disabled = zoom <= MIN_ZOOM;
+        zoomInButton.disabled = zoom >= MAX_ZOOM;
+        zoomResetButton.textContent = `${Math.round(zoom * 100)}%`;
+        zoomResetButton.disabled = zoom === 1;
+    }
+
+    function applyZoom(resetScroll = false) {
+        if (!viewerStage || !viewerImage || !viewerImage.naturalWidth || !viewerImage.naturalHeight) {
+            setZoomState();
+            return;
+        }
+
+        const availableWidth = Math.max(viewerStage.clientWidth - 32, 1);
+        const availableHeight = Math.max(viewerStage.clientHeight - 32, 1);
+        const fitScale = Math.min(
+            availableWidth / viewerImage.naturalWidth,
+            availableHeight / viewerImage.naturalHeight,
+            1,
+        );
+        const displayScale = fitScale * zoom;
+
+        viewerImage.style.width = `${Math.round(viewerImage.naturalWidth * displayScale)}px`;
+        viewerImage.style.height = `${Math.round(viewerImage.naturalHeight * displayScale)}px`;
+
+        if (resetScroll) {
+            viewerStage.scrollTop = 0;
+            viewerStage.scrollLeft = 0;
+        }
+
+        setZoomState();
+    }
+
+    function setIndex(nextIndex: number) {
+        index = (nextIndex + images.length) % images.length;
+        previewImage.src = images[index];
+
+        if (viewerImage) {
+            viewerImage.src = images[index];
+            viewerImage.alt = `Photo ${index + 1}`;
+        }
+
+        if (viewerCount) {
+            viewerCount.textContent = `Photo ${index + 1} of ${images.length}`;
+        }
+
+        if (viewerLink) {
+            viewerLink.href = images[index];
+        }
+    }
+
+    function resetZoom() {
+        zoom = 1;
+        applyZoom(true);
+    }
+
+    function changeImage(step: number) {
+        setIndex(index + step);
+        resetZoom();
+    }
+
+    function openViewer() {
+        if (!viewer) return;
+
+        viewer.hidden = false;
+        document.body.style.overflow = "hidden";
+        setIndex(index);
+        resetZoom();
+        (viewer.querySelector("[data-image-viewer-close]") as HTMLButtonElement | null)?.focus();
+    }
+
+    function closeViewer() {
+        if (!viewer) return;
+
+        viewer.hidden = true;
+        document.body.style.overflow = "";
+    }
+
+    if (prevBtn) {
+        prevBtn.addEventListener("click", () => {
+            changeImage(-1);
+        });
+    }
+
+    if (nextBtn) {
+        nextBtn.addEventListener("click", () => {
+            changeImage(1);
+        });
+    }
+
+    openButtons.forEach((button) => {
+        button.addEventListener("click", openViewer);
     });
 
-    nextBtn.addEventListener("click", () => {
-        index = (index + 1) % images.length;
-        updateImage();
+    viewerPrev?.addEventListener("click", () => {
+        changeImage(-1);
     });
+
+    viewerNext?.addEventListener("click", () => {
+        changeImage(1);
+    });
+
+    zoomOutButton?.addEventListener("click", () => {
+        zoom = Math.max(MIN_ZOOM, zoom - ZOOM_STEP);
+        applyZoom();
+    });
+
+    zoomInButton?.addEventListener("click", () => {
+        zoom = Math.min(MAX_ZOOM, zoom + ZOOM_STEP);
+        applyZoom();
+    });
+
+    zoomResetButton?.addEventListener("click", resetZoom);
+
+    closeButtons?.forEach((button) => {
+        button.addEventListener("click", closeViewer);
+    });
+
+    viewerImage?.addEventListener("load", () => {
+        applyZoom(true);
+    });
+
+    viewerImage?.addEventListener("dblclick", () => {
+        zoom = zoom === 1 ? 2 : 1;
+        applyZoom();
+    });
+
+    window.addEventListener("resize", () => {
+        if (!viewer?.hidden) {
+            applyZoom();
+        }
+    });
+
+    document.addEventListener("keydown", (event) => {
+        if (viewer?.hidden) return;
+
+        if (event.key === "Escape") {
+            closeViewer();
+            return;
+        }
+
+        if (event.key === "ArrowLeft") {
+            changeImage(-1);
+            return;
+        }
+
+        if (event.key === "ArrowRight") {
+            changeImage(1);
+            return;
+        }
+
+        if (event.key === "+" || event.key === "=") {
+            zoom = Math.min(MAX_ZOOM, zoom + ZOOM_STEP);
+            applyZoom();
+            return;
+        }
+
+        if (event.key === "-") {
+            zoom = Math.max(MIN_ZOOM, zoom - ZOOM_STEP);
+            applyZoom();
+            return;
+        }
+
+        if (event.key === "0") {
+            resetZoom();
+        }
+    });
+
+    setViewerNavigationState();
+    setIndex(0);
+    setZoomState();
 });

--- a/wine_cellar/templates/includes/detail_image_viewer.html
+++ b/wine_cellar/templates/includes/detail_image_viewer.html
@@ -1,0 +1,126 @@
+{% if detail_images %}
+    {{ detail_images|json_script:"beverage-detail-images" }}
+{% endif %}
+<div class="wine-detail__image-wrapper">
+    {% if detail_images %}
+        <button type="button"
+                class="wine-detail__image-button"
+                data-image-viewer-open
+                aria-controls="beverage-image-viewer"
+                aria-haspopup="dialog"
+                aria-label="View photos for {{ beverage.name }}">
+            <div class="image wine-detail__image" id="wine-image-wrapper">
+                <img id="wine-image"
+                     src="{{ preview_image }}"
+                     loading="lazy"
+                     height="225"
+                     width="auto"
+                     alt="{{ image_alt }}">
+            </div>
+        </button>
+        {% if detail_images|length > 1 %}
+            <div class="image-controls" role="group" aria-label="Image carousel controls">
+                <button type="button"
+                        class="wine-prev"
+                        aria-label="Previous image"
+                        title="Previous image">«</button>
+                <button type="button"
+                        class="wine-next"
+                        aria-label="Next image"
+                        title="Next image">»</button>
+            </div>
+        {% endif %}
+    {% else %}
+        <div class="image wine-detail__image" id="wine-image-wrapper">
+            <img id="wine-image"
+                 src="{{ preview_image }}"
+                 loading="lazy"
+                 height="225"
+                 width="auto"
+                 alt="{{ image_alt }}">
+        </div>
+    {% endif %}
+</div>
+<div class="wine-detail__image-actions">
+    {% if detail_images %}
+        <button type="button" class="pure-button button__neutral" data-image-viewer-open>
+            <i class="fa-solid fa-images"></i> View Photos
+        </button>
+    {% endif %}
+    <a href="{{ edit_url }}" class="pure-button button__neutral">
+        <i class="fa-solid fa-crop"></i> Edit Images
+    </a>
+</div>
+{% if detail_images %}
+    <div id="beverage-image-viewer"
+         class="image-viewer"
+         hidden
+         role="dialog"
+         aria-modal="true"
+         aria-labelledby="beverage-image-viewer-title">
+        <div class="image-viewer__backdrop" data-image-viewer-close></div>
+        <div class="image-viewer__sheet">
+            <div class="image-viewer__header">
+                <div>
+                    <p id="beverage-image-viewer-title" class="image-viewer__title">{{ beverage.name }}</p>
+                    <p id="beverage-image-viewer-count" class="image-viewer__meta"></p>
+                </div>
+                <button type="button"
+                        class="image-viewer__icon-button"
+                        data-image-viewer-close
+                        aria-label="Close photo viewer">
+                    <i class="fa-solid fa-xmark"></i>
+                </button>
+            </div>
+            <div class="image-viewer__toolbar">
+                <div class="image-viewer__control-group">
+                    <button type="button"
+                            class="image-viewer__icon-button"
+                            data-image-viewer-prev
+                            aria-label="Previous photo">
+                        <i class="fa-solid fa-chevron-left"></i>
+                    </button>
+                    <button type="button"
+                            class="image-viewer__icon-button"
+                            data-image-viewer-next
+                            aria-label="Next photo">
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </button>
+                </div>
+                <div class="image-viewer__control-group">
+                    <button type="button"
+                            class="image-viewer__icon-button"
+                            data-image-viewer-zoom-out
+                            aria-label="Zoom out">
+                        <i class="fa-solid fa-magnifying-glass-minus"></i>
+                    </button>
+                    <button type="button"
+                            class="image-viewer__zoom-reset"
+                            data-image-viewer-reset
+                            aria-label="Reset zoom">100%</button>
+                    <button type="button"
+                            class="image-viewer__icon-button"
+                            data-image-viewer-zoom-in
+                            aria-label="Zoom in">
+                        <i class="fa-solid fa-magnifying-glass-plus"></i>
+                    </button>
+                </div>
+                <a id="beverage-image-viewer-link"
+                   class="image-viewer__open-link"
+                   href="{{ detail_images.0 }}"
+                   target="_blank"
+                   rel="noopener">
+                    <i class="fa-solid fa-up-right-from-square"></i> Open original
+                </a>
+            </div>
+            <div id="beverage-image-viewer-stage" class="image-viewer__stage">
+                <div class="image-viewer__canvas">
+                    <img id="beverage-image-viewer-image"
+                         class="image-viewer__image"
+                         src="{{ detail_images.0 }}"
+                         alt="{{ image_alt }}">
+                </div>
+            </div>
+        </div>
+    </div>
+{% endif %}

--- a/wine_cellar/templates/includes/detail_image_viewer.html
+++ b/wine_cellar/templates/includes/detail_image_viewer.html
@@ -1,6 +1,3 @@
-{% if detail_images %}
-    {{ detail_images|json_script:"beverage-detail-images" }}
-{% endif %}
 <div class="wine-detail__image-wrapper">
     {% if detail_images %}
         <button type="button"
@@ -10,12 +7,16 @@
                 aria-haspopup="dialog"
                 aria-label="View photos for {{ beverage.name }}">
             <div class="image wine-detail__image" id="wine-image-wrapper">
-                <img id="wine-image"
-                     src="{{ preview_image }}"
-                     loading="lazy"
-                     height="225"
-                     width="auto"
-                     alt="{{ image_alt }}">
+                {% for image_url in detail_images %}
+                    <img src="{{ image_url }}"
+                         class="wine-detail__preview-image"
+                         data-preview-image
+                         loading="lazy"
+                         height="225"
+                         width="auto"
+                         alt="{{ image_alt }}"
+                         {% if not forloop.first %}hidden{% endif %}>
+                {% endfor %}
             </div>
         </button>
         {% if detail_images|length > 1 %}
@@ -105,20 +106,27 @@
                         <i class="fa-solid fa-magnifying-glass-plus"></i>
                     </button>
                 </div>
-                <a id="beverage-image-viewer-link"
-                   class="image-viewer__open-link"
-                   href="{{ detail_images.0 }}"
-                   target="_blank"
-                   rel="noopener">
-                    <i class="fa-solid fa-up-right-from-square"></i> Open original
-                </a>
+                {% for image_url in detail_images %}
+                    <a class="image-viewer__open-link"
+                       data-image-viewer-link
+                       href="{{ image_url }}"
+                       target="_blank"
+                       rel="noopener"
+                       {% if not forloop.first %}hidden{% endif %}>
+                        <i class="fa-solid fa-up-right-from-square"></i> Open original
+                    </a>
+                {% endfor %}
             </div>
             <div id="beverage-image-viewer-stage" class="image-viewer__stage">
                 <div class="image-viewer__canvas">
-                    <img id="beverage-image-viewer-image"
-                         class="image-viewer__image"
-                         src="{{ detail_images.0 }}"
-                         alt="{{ image_alt }}">
+                    {% for image_url in detail_images %}
+                        <img class="image-viewer__image"
+                             data-image-viewer-image
+                             src="{{ image_url }}"
+                             loading="lazy"
+                             alt="{{ image_alt }}"
+                             {% if not forloop.first %}hidden{% endif %}>
+                    {% endfor %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a shared fullscreen detail-page photo viewer for wine and whisky
- support carousel navigation, zoom controls, and opening the original image for label reading
- harden detail-page media URL handling in the viewer and preserve accessible focus/alt behavior
- add focused detail-view and model coverage for the new viewer flow

## Testing
- /root/wine-cellar-personal/venv/bin/py.test tests/test_wine_model.py::test_image_properties_use_prefetch_cache tests/test_core_views.py::TestWineDetailView::test_detail_view_renders_photo_viewer_controls --reuse-db
- CELLAR_APP_TYPE=whisky /root/wine-cellar-personal/venv/bin/py.test tests/whisky/test_views.py::test_whisky_detail_shows_carousel_controls_for_multiple_images --reuse-db
- venv/bin/python manage.py check
- CELLAR_APP_TYPE=whisky venv/bin/python manage.py check
- npm run lint -- wine_cellar/assets/js/wine_carousel.ts

Closes #230