### PR TITLE
integrate ai grape inference into wine add flow

### DIFF
--- a/tests/test_ai_grape_service.py
+++ b/tests/test_ai_grape_service.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from wine_cellar.apps.wine.models import Grape
 from wine_cellar.apps.wine.services.ai_grapes import WineAIGrapeService
 
 
@@ -31,7 +32,7 @@ def test_refresh_grapes_links_existing_and_new_grapes(
     existing_grape = grape_factory(
         user=user,
         household=user.user_settings.active_household,
-        name="Riesling",
+        name="RIESLING",
     )
 
     captured = {}
@@ -56,9 +57,10 @@ def test_refresh_grapes_links_existing_and_new_grapes(
 
     wine.refresh_from_db()
     assert set(wine.grapes.values_list("name", flat=True)) == {
-        "Riesling",
+        "RIESLING",
         "Cabernet Sauvignon",
     }
+    assert Grape.objects.filter(user=user, name__iexact="riesling").count() == 1
     assert captured["api_key"] == "test-key"
     assert captured["kwargs"]["model"] == "claude-haiku-test"
     assert "Wine Name" in captured["kwargs"]["messages"][0]["content"][0]["text"]
@@ -82,3 +84,29 @@ def test_refresh_grapes_skips_without_api_key(
 
     wine.refresh_from_db()
     assert wine.grapes.count() == 0
+
+
+@pytest.mark.django_db
+def test_refresh_grapes_reads_text_from_later_content_blocks(
+    settings, monkeypatch, user, wine_factory
+):
+    settings.ANTHROPIC_API_KEY = "test-key"
+    wine = wine_factory(user=user)
+    wine.grapes.clear()
+
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="tool_use"),
+            SimpleNamespace(text="GRAPES: Riesling\nCONFIDENCE: medium"),
+        ]
+    )
+
+    monkeypatch.setattr(
+        "wine_cellar.apps.wine.services.ai_grapes.anthropic.Anthropic",
+        lambda api_key: _FakeAnthropicClient(response, {}),
+    )
+
+    assert WineAIGrapeService.refresh_grapes(wine.pk, include_images=False) is True
+
+    wine.refresh_from_db()
+    assert list(wine.grapes.values_list("name", flat=True)) == ["Riesling"]

--- a/tests/test_ai_grape_service.py
+++ b/tests/test_ai_grape_service.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+import pytest
+
+from wine_cellar.apps.wine.services.ai_grapes import WineAIGrapeService
+
+
+class _FakeMessagesClient:
+    def __init__(self, response, captured):
+        self._response = response
+        self._captured = captured
+
+    def create(self, **kwargs):
+        self._captured["kwargs"] = kwargs
+        return self._response
+
+
+class _FakeAnthropicClient:
+    def __init__(self, response, captured):
+        self.messages = _FakeMessagesClient(response, captured)
+
+
+@pytest.mark.django_db
+def test_refresh_grapes_links_existing_and_new_grapes(
+    settings, monkeypatch, user, wine_factory, grape_factory
+):
+    settings.ANTHROPIC_API_KEY = "test-key"
+    settings.WINE_AI_GRAPES_MODEL = "claude-haiku-test"
+    wine = wine_factory(user=user)
+    wine.grapes.clear()
+    existing_grape = grape_factory(
+        user=user,
+        household=user.user_settings.active_household,
+        name="Riesling",
+    )
+
+    captured = {}
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(
+                text="GRAPES: riesling, cab sav\nCONFIDENCE: high",
+            )
+        ]
+    )
+
+    def fake_client(api_key):
+        captured["api_key"] = api_key
+        return _FakeAnthropicClient(response, captured)
+
+    monkeypatch.setattr(
+        "wine_cellar.apps.wine.services.ai_grapes.anthropic.Anthropic",
+        fake_client,
+    )
+
+    assert WineAIGrapeService.refresh_grapes(wine.pk, include_images=False) is True
+
+    wine.refresh_from_db()
+    assert set(wine.grapes.values_list("name", flat=True)) == {
+        "Riesling",
+        "Cabernet Sauvignon",
+    }
+    assert captured["api_key"] == "test-key"
+    assert captured["kwargs"]["model"] == "claude-haiku-test"
+    assert "Wine Name" in captured["kwargs"]["messages"][0]["content"][0]["text"]
+    assert wine.grapes.filter(pk=existing_grape.pk).exists()
+
+
+@pytest.mark.django_db
+def test_refresh_grapes_skips_without_api_key(
+    settings, monkeypatch, user, wine_factory
+):
+    settings.ANTHROPIC_API_KEY = ""
+    wine = wine_factory(user=user)
+    wine.grapes.clear()
+
+    monkeypatch.setattr(
+        "wine_cellar.apps.wine.services.ai_grapes.anthropic.Anthropic",
+        lambda api_key: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
+
+    assert WineAIGrapeService.refresh_grapes(wine.pk) is False
+
+    wine.refresh_from_db()
+    assert wine.grapes.count() == 0

--- a/tests/test_wine_form_submission.py
+++ b/tests/test_wine_form_submission.py
@@ -70,6 +70,12 @@ class TestWineCreateView:
             patch(
                 (
                     "wine_cellar.apps.wine.views.wine_crud."
+                    "WineAIGrapeService.refresh_grapes"
+                )
+            ) as refresh_grapes,
+            patch(
+                (
+                    "wine_cellar.apps.wine.views.wine_crud."
                     "WineAISummaryService.refresh_summary"
                 )
             ) as refresh_summary,
@@ -84,6 +90,43 @@ class TestWineCreateView:
         assert wine.wine_type == "RE"
         assert wine.country == "FR"
         assert wine.user == user
+        refresh_grapes.assert_called_once_with(wine.pk)
+        refresh_summary.assert_called_once_with(wine.pk)
+
+    def test_create_with_manual_grapes_skips_ai_grape_refresh(
+        self, client, user, grape_factory
+    ):
+        """Manual grape selections should not trigger AI grape inference."""
+        client.force_login(user)
+        grape = grape_factory(user=user, household=user.user_settings.active_household)
+        with (
+            patch(
+                (
+                    "wine_cellar.apps.wine.views.wine_crud."
+                    "WineAIGrapeService.refresh_grapes"
+                )
+            ) as refresh_grapes,
+            patch(
+                (
+                    "wine_cellar.apps.wine.views.wine_crud."
+                    "WineAISummaryService.refresh_summary"
+                )
+            ) as refresh_summary,
+            patch(
+                "wine_cellar.apps.wine.views.wine_crud.transaction.on_commit",
+                side_effect=lambda callback: callback(),
+            ),
+        ):
+            r = client.post(
+                reverse("wine-add"),
+                _minimal_wine_data(grapes=[str(grape.pk)]),
+                follow=True,
+            )
+
+        assert r.status_code == 200
+        wine = Wine.objects.get(name="Test Wine")
+        assert list(wine.grapes.values_list("pk", flat=True)) == [grape.pk]
+        refresh_grapes.assert_not_called()
         refresh_summary.assert_called_once_with(wine.pk)
 
     def test_create_with_optional_fields(self, client, user):
@@ -373,6 +416,38 @@ def test_schedule_ai_summary_refresh_swallows_exceptions(monkeypatch):
     wine_crud._schedule_ai_summary_refresh(123)
 
     assert logged == [("Unexpected error generating AI summary for wine %s", 123)]
+
+
+@pytest.mark.django_db
+def test_schedule_ai_grape_refresh_swallows_exceptions(monkeypatch):
+    module_path = (
+        Path(__file__).resolve().parents[1] / "wine_cellar/apps/wine/views/wine_crud.py"
+    )
+    spec = util.spec_from_file_location("test_wine_crud_module", module_path)
+    assert spec and spec.loader
+    wine_crud = util.module_from_spec(spec)
+    spec.loader.exec_module(wine_crud)
+    logged = []
+
+    monkeypatch.setattr(
+        wine_crud.WineAIGrapeService,
+        "refresh_grapes",
+        lambda wine_id: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(
+        wine_crud.transaction,
+        "on_commit",
+        lambda callback: callback(),
+    )
+    monkeypatch.setattr(
+        wine_crud.logger,
+        "exception",
+        lambda message, wine_id: logged.append((message, wine_id)),
+    )
+
+    wine_crud._schedule_ai_grape_refresh(123)
+
+    assert logged == [("Unexpected error generating AI grapes for wine %s", 123)]
 
 
 @pytest.mark.django_db

--- a/tests/test_wine_form_submission.py
+++ b/tests/test_wine_form_submission.py
@@ -129,6 +129,45 @@ class TestWineCreateView:
         refresh_grapes.assert_not_called()
         refresh_summary.assert_called_once_with(wine.pk)
 
+    def test_existing_wine_path_skips_ai_grape_refresh(self, client, user):
+        client.force_login(user)
+        storage = user.storage_set.first()
+        first_response = client.post(
+            reverse("wine-add"), _minimal_wine_data(), follow=True
+        )
+        assert first_response.status_code == 200
+
+        wine = Wine.objects.get(name="Test Wine")
+        wine.grapes.clear()
+
+        with (
+            patch(
+                (
+                    "wine_cellar.apps.wine.views.wine_crud."
+                    "WineAIGrapeService.refresh_grapes"
+                )
+            ) as refresh_grapes,
+            patch(
+                (
+                    "wine_cellar.apps.wine.views.wine_crud."
+                    "WineAISummaryService.refresh_summary"
+                )
+            ) as refresh_summary,
+            patch(
+                "wine_cellar.apps.wine.views.wine_crud.transaction.on_commit",
+                side_effect=lambda callback: callback(),
+            ),
+        ):
+            second_response = client.post(
+                reverse("wine-add"),
+                _minimal_wine_data(storage=storage.pk, row=1, column=1),
+                follow=True,
+            )
+
+        assert second_response.status_code == 200
+        refresh_grapes.assert_not_called()
+        refresh_summary.assert_called_once_with(wine.pk)
+
     def test_create_with_optional_fields(self, client, user):
         """POST with optional fields populates them on the wine."""
         client.force_login(user)

--- a/wine_cellar/apps/wine/management/commands/populate_grapes.py
+++ b/wine_cellar/apps/wine/management/commands/populate_grapes.py
@@ -1,69 +1,12 @@
 """Batch populate grape varieties for wines using Claude AI."""
 
-import re
 import time
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from wine_cellar.apps.wine.models import Grape, Wine
-from wine_cellar.apps.wine.services.grape_normalization import (
-    normalize_grape_list,
-)
-
-
-def build_grape_prompt(wine):
-    """Build a Claude prompt to identify grape varieties for a wine."""
-    import pycountry
-
-    country_name = "Unknown"
-    if wine.country:
-        country = pycountry.countries.get(alpha_2=wine.country)
-        if country:
-            country_name = country.name
-
-    wine_type_display = wine.get_wine_type_display() if wine.wine_type else "Unknown"
-
-    return f"""You are a wine expert. Given the following wine information, \
-identify the most likely grape varieties used to make this wine.
-
-Wine Name: {wine.name}
-Wine Type: {wine_type_display}
-Country: {country_name}
-Region: {wine.subregion or "Unknown"}
-Comment: {wine.comment or "None"}
-
-Rules:
-- Return ONLY grape variety names you are confident about
-- Use full canonical names in title case (e.g., "Cabernet Sauvignon")
-- For well-known regional wines, infer grapes from the appellation/region
-- If the wine name itself is a grape variety, include it
-- If you cannot determine the grapes with reasonable confidence, return "not found"
-- Do not guess wildly - only return grapes you would bet on
-
-Return in this exact format:
-GRAPES: grape1, grape2, grape3
-CONFIDENCE: high/medium/low"""
-
-
-def parse_grape_response(response_text):
-    """Parse a Claude response for grape names and confidence."""
-    grapes = []
-    confidence = "low"
-
-    grape_match = re.search(r"GRAPES:\s*(.+?)(?:\n|$)", response_text, re.IGNORECASE)
-    if grape_match:
-        raw = grape_match.group(1).strip()
-        if raw.lower() != "not found":
-            grapes = normalize_grape_list(raw.split(","))
-
-    conf_match = re.search(r"CONFIDENCE:\s*(.+?)(?:\n|$)", response_text, re.IGNORECASE)
-    if conf_match:
-        conf = conf_match.group(1).strip().lower()
-        if conf in ("high", "medium", "low"):
-            confidence = conf
-
-    return grapes, confidence
+from wine_cellar.apps.wine.services.ai_grapes import WineAIGrapeService
 
 
 class Command(BaseCommand):
@@ -105,12 +48,6 @@ class Command(BaseCommand):
             )
             return
 
-        try:
-            import anthropic
-        except ImportError:
-            self.stderr.write(self.style.ERROR("anthropic package not installed"))
-            return
-
         commit = options["commit"]
         mode = "COMMIT" if commit else "DRY RUN"
         delay = options["delay"]
@@ -134,8 +71,6 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Found {total} wines to process\n")
 
-        client = anthropic.Anthropic(api_key=api_key)
-
         wines_updated = 0
         grapes_linked = 0
         grapes_created = 0
@@ -144,55 +79,10 @@ class Command(BaseCommand):
 
         for idx, wine in enumerate(wines, 1):
             try:
-                # Build prompt
-                prompt_text = build_grape_prompt(wine)
-
-                # Build content
-                content = []
-
-                # Optionally include label images
-                if not options["skip_images"]:
-                    images = list(wine.wineimage_set.all())[:2]
-                    for img in images:
-                        try:
-                            import base64
-
-                            from wine_cellar.apps.wine.services.vision_extraction import (  # noqa: E501
-                                resize_image_for_api,
-                            )
-
-                            with img.image.open("rb") as f:
-                                image_data = f.read()
-                            b64 = base64.b64encode(image_data).decode("utf-8")
-                            resized = resize_image_for_api(b64)
-                            content.append(
-                                {
-                                    "type": "image",
-                                    "source": {
-                                        "type": "base64",
-                                        "media_type": "image/jpeg",
-                                        "data": resized,
-                                    },
-                                }
-                            )
-                        except Exception as e:
-                            self.stdout.write(
-                                self.style.WARNING(
-                                    f"  Could not load image for wine {wine.pk}: {e}"
-                                )
-                            )
-
-                content.append({"type": "text", "text": prompt_text})
-
-                # Call Claude API
-                response = client.messages.create(
-                    model="claude-haiku-4-5",
-                    max_tokens=256,
-                    messages=[{"role": "user", "content": content}],
+                grape_names, confidence = WineAIGrapeService.identify_grapes(
+                    wine,
+                    include_images=not options["skip_images"],
                 )
-
-                response_text = response.content[0].text
-                grape_names, confidence = parse_grape_response(response_text)
 
                 wine_type = wine.get_wine_type_display() if wine.wine_type else "?"
                 self.stdout.write(

--- a/wine_cellar/apps/wine/services/__init__.py
+++ b/wine_cellar/apps/wine/services/__init__.py
@@ -1,5 +1,6 @@
 """Wine app services."""
 
+from .ai_grapes import WineAIGrapeService
 from .ai_summary import WineAISummaryService
 from .barcode_service import BarcodeScanner
 from .creation import WineCreationService
@@ -7,6 +8,7 @@ from .reminders import WineReminderService
 from .vision_extraction import WineVisionExtractor
 
 __all__ = [
+    "WineAIGrapeService",
     "WineAISummaryService",
     "BarcodeScanner",
     "WineCreationService",

--- a/wine_cellar/apps/wine/services/ai_grapes.py
+++ b/wine_cellar/apps/wine/services/ai_grapes.py
@@ -7,6 +7,7 @@ import re
 import anthropic
 import pycountry
 from django.conf import settings
+from django.db import IntegrityError
 
 from wine_cellar.apps.wine.models import Grape, ImageType, Wine
 from wine_cellar.apps.wine.services.grape_normalization import normalize_grape_list
@@ -56,10 +57,9 @@ class WineAIGrapeService:
 
         grapes = []
         for grape_name in grape_names:
-            grape, _created = Grape.objects.get_or_create(
-                name=grape_name,
-                user=wine.user,
-                defaults={"household": wine.household},
+            grape = cls._get_or_create_grape(
+                wine=wine,
+                grape_name=grape_name,
             )
             grapes.append(grape)
 
@@ -83,7 +83,9 @@ class WineAIGrapeService:
             ],
         )
 
-        response_text = response.content[0].text
+        response_text = cls._extract_response_text(
+            getattr(response, "content", []) or []
+        )
         return cls.parse_response(response_text)
 
     @staticmethod
@@ -193,3 +195,36 @@ class WineAIGrapeService:
                 )
 
         return content
+
+    @staticmethod
+    def _extract_response_text(content_blocks) -> str:
+        parts = []
+        for block in content_blocks:
+            text = getattr(block, "text", "")
+            if text:
+                parts.append(text.strip())
+        return "\n\n".join(part for part in parts if part)
+
+    @staticmethod
+    def _get_or_create_grape(*, wine: Wine, grape_name: str) -> Grape:
+        existing = Grape.objects.filter(
+            name__iexact=grape_name,
+            user=wine.user,
+        ).first()
+        if existing:
+            return existing
+
+        try:
+            return Grape.objects.create(
+                name=grape_name,
+                user=wine.user,
+                household=wine.household,
+            )
+        except IntegrityError:
+            existing = Grape.objects.filter(
+                name__iexact=grape_name,
+                user=wine.user,
+            ).first()
+            if existing:
+                return existing
+            raise

--- a/wine_cellar/apps/wine/services/ai_grapes.py
+++ b/wine_cellar/apps/wine/services/ai_grapes.py
@@ -1,0 +1,195 @@
+"""AI grape inference service for wines with missing grape data."""
+
+import base64
+import logging
+import re
+
+import anthropic
+import pycountry
+from django.conf import settings
+
+from wine_cellar.apps.wine.models import Grape, ImageType, Wine
+from wine_cellar.apps.wine.services.grape_normalization import normalize_grape_list
+from wine_cellar.apps.wine.services.vision_extraction import resize_image_for_api
+
+logger = logging.getLogger(__name__)
+
+
+class WineAIGrapeService:
+    """Infer and persist grape varieties for wines."""
+
+    DEFAULT_MODEL = "claude-haiku-4-5"
+
+    @classmethod
+    def refresh_grapes(cls, wine_id: int, *, include_images: bool = True) -> bool:
+        """Populate missing grapes for a wine."""
+        if not settings.ANTHROPIC_API_KEY:
+            logger.info(
+                (
+                    "Skipping AI grape inference for wine %s: "
+                    "ANTHROPIC_API_KEY not configured"
+                ),
+                wine_id,
+            )
+            return False
+
+        wine = Wine.objects.with_related().filter(pk=wine_id, deleted=False).first()
+        if wine is None:
+            logger.warning(
+                "Skipping AI grape inference: wine %s was not found", wine_id
+            )
+            return False
+
+        if wine.grapes.exists():
+            return False
+
+        try:
+            grape_names, _confidence = cls.identify_grapes(
+                wine, include_images=include_images
+            )
+        except anthropic.APIError:
+            logger.exception("AI grape inference failed for wine %s", wine.pk)
+            return False
+
+        if not grape_names:
+            return False
+
+        grapes = []
+        for grape_name in grape_names:
+            grape, _created = Grape.objects.get_or_create(
+                name=grape_name,
+                user=wine.user,
+                defaults={"household": wine.household},
+            )
+            grapes.append(grape)
+
+        wine.grapes.add(*grapes)
+        return True
+
+    @classmethod
+    def identify_grapes(
+        cls, wine: Wine, *, include_images: bool = True
+    ) -> tuple[list[str], str]:
+        """Return inferred grapes and model confidence for a wine."""
+        client = anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+        response = client.messages.create(
+            model=getattr(settings, "WINE_AI_GRAPES_MODEL", cls.DEFAULT_MODEL),
+            max_tokens=256,
+            messages=[
+                {
+                    "role": "user",
+                    "content": cls._build_content(wine, include_images=include_images),
+                }
+            ],
+        )
+
+        response_text = response.content[0].text
+        return cls.parse_response(response_text)
+
+    @staticmethod
+    def build_prompt(wine: Wine) -> str:
+        """Build a prompt to identify likely grape varieties."""
+        country_name = "Unknown"
+        if wine.country:
+            country = pycountry.countries.get(alpha_2=wine.country)
+            if country:
+                country_name = country.name
+
+        wine_type_display = (
+            wine.get_wine_type_display() if wine.wine_type else "Unknown"
+        )
+
+        return (
+            "You are a wine expert. Given the following wine information, "
+            "identify the most likely grape varieties used to make this wine.\n\n"
+            f"Wine Name: {wine.name}\n"
+            f"Wine Type: {wine_type_display}\n"
+            f"Country: {country_name}\n"
+            f"Region: {wine.subregion or 'Unknown'}\n"
+            f"Comment: {wine.comment or 'None'}\n\n"
+            "Rules:\n"
+            "- Return ONLY grape variety names you are confident about\n"
+            '- Use full canonical names in title case (e.g., "Cabernet Sauvignon")\n'
+            "- For well-known regional wines, infer grapes from the "
+            "appellation/region\n"
+            "- If the wine name itself is a grape variety, include it\n"
+            "- If you cannot determine the grapes with reasonable confidence, "
+            'return "not found"\n'
+            "- Do not guess wildly - only return grapes you would bet on\n\n"
+            "Return in this exact format:\n"
+            "GRAPES: grape1, grape2, grape3\n"
+            "CONFIDENCE: high/medium/low"
+        )
+
+    @staticmethod
+    def parse_response(response_text: str) -> tuple[list[str], str]:
+        """Parse a model response into normalized grapes and confidence."""
+        grapes = []
+        confidence = "low"
+
+        grape_match = re.search(
+            r"GRAPES:\s*(.+?)(?:\n|$)", response_text, re.IGNORECASE
+        )
+        if grape_match:
+            raw = grape_match.group(1).strip()
+            if raw.lower() != "not found":
+                grapes = normalize_grape_list(raw.split(","))
+
+        conf_match = re.search(
+            r"CONFIDENCE:\s*(.+?)(?:\n|$)", response_text, re.IGNORECASE
+        )
+        if conf_match:
+            parsed_confidence = conf_match.group(1).strip().lower()
+            if parsed_confidence in ("high", "medium", "low"):
+                confidence = parsed_confidence
+
+        return grapes, confidence
+
+    @classmethod
+    def _build_content(cls, wine: Wine, *, include_images: bool) -> list[dict]:
+        content = []
+        if include_images:
+            content.extend(cls._build_image_content(wine))
+        content.append({"type": "text", "text": cls.build_prompt(wine)})
+        return content
+
+    @staticmethod
+    def _build_image_content(wine: Wine) -> list[dict]:
+        content = []
+        images = sorted(
+            wine.wineimage_set.all(),
+            key=lambda image: (
+                {
+                    ImageType.LABEL_FRONT: 0,
+                    ImageType.LABEL_BACK: 1,
+                }.get(image.image_type, 99),
+                image.pk,
+            ),
+        )[:2]
+
+        for image in images:
+            try:
+                with image.image.open("rb") as file_obj:
+                    image_data = file_obj.read()
+                resized = resize_image_for_api(
+                    base64.b64encode(image_data).decode("utf-8")
+                )
+                content.append(
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/jpeg",
+                            "data": resized,
+                        },
+                    }
+                )
+            except Exception:
+                logger.warning(
+                    "Could not load image %s for AI grape inference on wine %s",
+                    image.pk,
+                    wine.pk,
+                    exc_info=True,
+                )
+
+        return content

--- a/wine_cellar/apps/wine/views/wine_crud.py
+++ b/wine_cellar/apps/wine/views/wine_crud.py
@@ -37,7 +37,7 @@ from wine_cellar.apps.wine.models import (
     WineImage,
     Wishlist,
 )
-from wine_cellar.apps.wine.services import WineAISummaryService
+from wine_cellar.apps.wine.services import WineAIGrapeService, WineAISummaryService
 from wine_cellar.apps.wine.services.creation import WineCreationService
 
 logger = logging.getLogger(__name__)
@@ -61,6 +61,18 @@ def _schedule_ai_summary_refresh(wine_id):
         except Exception:
             logger.exception(
                 "Unexpected error generating AI summary for wine %s", wine_id
+            )
+
+    transaction.on_commit(_callback)
+
+
+def _schedule_ai_grape_refresh(wine_id):
+    def _callback():
+        try:
+            WineAIGrapeService.refresh_grapes(wine_id)
+        except Exception:
+            logger.exception(
+                "Unexpected error generating AI grapes for wine %s", wine_id
             )
 
     transaction.on_commit(_callback)
@@ -229,6 +241,9 @@ class WineCreateView(BaseBeverageCreateView):
 
     def post_create(self, beverage, created):
         """Apply AI label bounds as auto-crop thumbnails if confidence is sufficient."""
+        if not beverage.grapes.exists():
+            _schedule_ai_grape_refresh(beverage.pk)
+
         if created:
             extraction_result = self.request.session.get("extraction_result")
             if extraction_result:

--- a/wine_cellar/apps/wine/views/wine_crud.py
+++ b/wine_cellar/apps/wine/views/wine_crud.py
@@ -241,7 +241,7 @@ class WineCreateView(BaseBeverageCreateView):
 
     def post_create(self, beverage, created):
         """Apply AI label bounds as auto-crop thumbnails if confidence is sufficient."""
-        if not beverage.grapes.exists():
+        if created and not beverage.grapes.exists():
             _schedule_ai_grape_refresh(beverage.pk)
 
         if created:


### PR DESCRIPTION
## Summary
- extract the grape inference logic into a reusable AI service
- trigger AI grape inference automatically during wine creation when grapes are still empty
- reuse the same service from the populate_grapes command and cover the flow with tests