### PR TITLE
fix ghcr latest image build trigger

### DIFF
--- a/.github/workflows/rpi-docker.yml
+++ b/.github/workflows/rpi-docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main", "next" ]
     paths:
+      - '.github/workflows/rpi-docker.yml'
       - 'wine_cellar/**'
       - 'fixtures/**'
       - 'requirements/**'
@@ -25,7 +26,6 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/next' || startsWith(github.event.head_commit.message, 'bump:')
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- remove the job-level guard that prevented the GHCR build from running on normal main pushes
- keep `latest` on main and `next` on next, but make both branch pushes actually publish their image tags
- include the workflow file in the path filter so workflow updates trigger a rebuild when merged