### PR TITLE
Fix stale offline bottle sync after soft deletes

### DIFF
--- a/tests/test_cellar_sync_api.py
+++ b/tests/test_cellar_sync_api.py
@@ -152,7 +152,9 @@ class TestApiCellarSync:
         assert "app_type" in data
         assert "currency" in data
         assert "beverages" in data
+        assert "deleted_beverage_ids" in data
         assert "stock_items" in data
+        assert "deleted_stock_item_ids" in data
         assert "storages" in data
         assert "is_incremental" in data
         assert data["is_incremental"] is False
@@ -223,6 +225,45 @@ class TestApiCellarSync:
         names = [b["name"] for b in data["beverages"]]
         assert "New Wine" in names
         assert "Old Wine" not in names
+
+    def test_incremental_sync_reports_deleted_wines(self, client, user, wine_factory):
+        wine = wine_factory(user=user, name="Deleted Later")
+        since = wine.modified.isoformat()
+        wine.deleted = True
+        wine.save_with_modified(update_fields=["deleted"])
+
+        client.force_login(user)
+        response = client.get(self.url, {"since": since})
+        data = json.loads(response.content)
+
+        assert data["is_incremental"] is True
+        assert data["beverages"] == []
+        assert data["deleted_beverage_ids"] == [wine.pk]
+
+    def test_incremental_sync_reports_consumed_bottles(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        wine = wine_factory(user=user, name="Consumable Wine")
+        storage = user.storage_set.first()
+        bottle = storage_item_factory(storage=storage, wine=wine, user=user)
+        since = bottle.modified.isoformat()
+
+        client.force_login(user)
+        response = client.post(
+            reverse("drink-record-add", kwargs={"pk": wine.pk}),
+            {
+                "date_consumed": "2024-01-15",
+                "storage_item": bottle.pk,
+            },
+        )
+        assert response.status_code == 302
+
+        sync_response = client.get(self.url, {"since": since})
+        data = json.loads(sync_response.content)
+
+        assert data["is_incremental"] is True
+        assert data["stock_items"] == []
+        assert data["deleted_stock_item_ids"] == [bottle.pk]
 
     def test_invalid_since_returns_400(self, client, user):
         client.force_login(user)

--- a/wine_cellar/apps/api/mixins.py
+++ b/wine_cellar/apps/api/mixins.py
@@ -35,7 +35,7 @@ class HouseholdScopedViewSetMixin:
 
                 instance.finished_date = timezone.now().date()
                 update_fields.append("finished_date")
-            instance.save(update_fields=update_fields)
+            instance.save_with_modified(update_fields=update_fields)
         else:
             instance.delete()
 

--- a/wine_cellar/apps/core/api.py
+++ b/wine_cellar/apps/core/api.py
@@ -53,6 +53,19 @@ def _storage_to_dict(storage):
     }
 
 
+def _get_deleted_ids(model, household, since) -> list[int]:
+    """Return soft-deleted ids changed since the last incremental sync."""
+    if since is None:
+        return []
+    return list(
+        model.objects.filter(
+            household=household,
+            deleted=True,
+            modified__gt=since,
+        ).values_list("pk", flat=True)
+    )
+
+
 def _wine_to_dict(wine):
     """Serialize a Wine to a dict for offline access."""
     return {
@@ -145,6 +158,7 @@ def api_cellar_sync(request):
     if app_type == "whisky":
         from wine_cellar.apps.whisky.models import Whisky, WhiskyStorageItem
 
+        deleted_beverage_ids = _get_deleted_ids(Whisky, household, since)
         qs = (
             Whisky.objects.filter(household=household, deleted=False)
             .with_related()
@@ -155,6 +169,7 @@ def api_cellar_sync(request):
 
         beverages = [_whisky_to_dict(w) for w in qs]
 
+        deleted_stock_item_ids = _get_deleted_ids(WhiskyStorageItem, household, since)
         items_qs = WhiskyStorageItem.objects.filter(
             household=household, deleted=False
         ).select_related("storage", "whisky")
@@ -166,6 +181,7 @@ def api_cellar_sync(request):
         from wine_cellar.apps.storage.models import StorageItem
         from wine_cellar.apps.wine.models import Wine
 
+        deleted_beverage_ids = _get_deleted_ids(Wine, household, since)
         qs = (
             Wine.objects.filter(household=household, deleted=False)
             .with_related()
@@ -176,6 +192,7 @@ def api_cellar_sync(request):
 
         beverages = [_wine_to_dict(w) for w in qs]
 
+        deleted_stock_item_ids = _get_deleted_ids(StorageItem, household, since)
         items_qs = StorageItem.objects.filter(
             household=household, deleted=False
         ).select_related("storage", "wine")
@@ -196,7 +213,9 @@ def api_cellar_sync(request):
             "app_type": app_type,
             "currency": user_settings.currency if user_settings else "EUR",
             "beverages": beverages,
+            "deleted_beverage_ids": deleted_beverage_ids,
             "stock_items": stock_items,
+            "deleted_stock_item_ids": deleted_stock_item_ids,
             "storages": storages,
             "is_incremental": bool(since_raw),
         }

--- a/wine_cellar/apps/core/models.py
+++ b/wine_cellar/apps/core/models.py
@@ -55,5 +55,10 @@ class UserContentModel(models.Model):
         verbose_name="Modified",
     )
 
+    def save_with_modified(self, *, update_fields: list[str]) -> None:
+        """Persist selected fields while forcing modified to refresh."""
+        fields = list(dict.fromkeys([*update_fields, "modified"]))
+        self.save(update_fields=fields)
+
     class Meta:
         abstract = True

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -541,7 +541,7 @@ class BaseDrinkRecordCreateView(RequireMemberMixin, FormView):
         storage_item.given_date = None
         storage_item.recipient = ""
         storage_item.given_occasion = ""
-        storage_item.save(
+        storage_item.save_with_modified(
             update_fields=[
                 "deleted",
                 "finished_date",
@@ -649,7 +649,7 @@ class BaseMarkBottleGivenView(RequireMemberMixin, FormView):
         storage_item.given_date = form.cleaned_data["given_date"]
         storage_item.given_occasion = form.cleaned_data.get("given_occasion", "")
         storage_item.finished_date = None
-        storage_item.save(
+        storage_item.save_with_modified(
             update_fields=[
                 "deleted",
                 "removal_reason",
@@ -710,7 +710,7 @@ class BaseMarkBottleBrokenOrLostView(RequireMemberMixin, TemplateView):
         self.object.given_date = None
         self.object.recipient = ""
         self.object.given_occasion = ""
-        self.object.save(
+        self.object.save_with_modified(
             update_fields=[
                 "deleted",
                 "finished_date",
@@ -812,7 +812,7 @@ class BaseBeverageDeleteView(RequireMemberMixin, DeleteView):
     def form_valid(self, form):
         log_delete(self.request.user, self.object)
         self.object.deleted = True
-        self.object.save(update_fields=["deleted"])
+        self.object.save_with_modified(update_fields=["deleted"])
         return redirect(self.get_success_url())
 
 

--- a/wine_cellar/apps/storage/views.py
+++ b/wine_cellar/apps/storage/views.py
@@ -659,7 +659,7 @@ class BottleQuickLogView(BaseBottleQuickLogView):
         storage_item.given_date = None
         storage_item.recipient = ""
         storage_item.given_occasion = ""
-        storage_item.save(
+        storage_item.save_with_modified(
             update_fields=[
                 "deleted",
                 "finished_date",

--- a/wine_cellar/apps/whisky/admin.py
+++ b/wine_cellar/apps/whisky/admin.py
@@ -62,7 +62,7 @@ class WhiskyAdmin(admin.ModelAdmin):
         for whisky in queryset.filter(deleted=True):
             try:
                 whisky.deleted = False
-                whisky.save(update_fields=["deleted"])
+                whisky.save_with_modified(update_fields=["deleted"])
                 restored += 1
             except IntegrityError:
                 skipped += 1

--- a/wine_cellar/apps/whisky/views.py
+++ b/wine_cellar/apps/whisky/views.py
@@ -927,7 +927,7 @@ class DrinkRecordCreateView(BaseDrinkRecordCreateView):
             storage_item.given_date = None
             storage_item.recipient = ""
             storage_item.given_occasion = ""
-            storage_item.save(
+            storage_item.save_with_modified(
                 update_fields=[
                     "deleted",
                     "finished_date",

--- a/wine_cellar/apps/wine/admin.py
+++ b/wine_cellar/apps/wine/admin.py
@@ -33,7 +33,7 @@ class WineAdmin(admin.ModelAdmin):
         for wine in queryset.filter(deleted=True):
             try:
                 wine.deleted = False
-                wine.save(update_fields=["deleted"])
+                wine.save_with_modified(update_fields=["deleted"])
                 restored += 1
             except IntegrityError:
                 skipped += 1

--- a/wine_cellar/apps/wine/views/bulk.py
+++ b/wine_cellar/apps/wine/views/bulk.py
@@ -3,6 +3,7 @@ import logging
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect
+from django.utils import timezone
 from django.views.decorators.http import require_POST
 
 from wine_cellar.apps.core.audit import log_delete
@@ -30,7 +31,7 @@ def bulk_action_view(request):
     if action == "delete":
         for wine in wines:
             log_delete(request.user, wine)
-        wines.update(deleted=True)
+        wines.update(deleted=True, modified=timezone.now())
         messages.success(request, f"Deleted {count} wine(s).")
     elif action == "update_drink_to":
         drink_to = request.POST.get("drink_to_year")

--- a/wine_cellar/assets/js/offline_store.ts
+++ b/wine_cellar/assets/js/offline_store.ts
@@ -9,12 +9,15 @@
 
 const DB_NAME = 'cellar-offline';
 const DB_VERSION = 2;
+const SYNC_STATE_VERSION = '2';
 
 interface CellarSyncResponse {
   app_type: string;
   currency: string;
   beverages: Record<string, unknown>[];
+  deleted_beverage_ids: number[];
   stock_items: Record<string, unknown>[];
+  deleted_stock_item_ids: number[];
   storages: Record<string, unknown>[];
   is_incremental: boolean;
 }
@@ -85,6 +88,22 @@ async function clearAndPutAll(
   });
 }
 
+async function deleteAll(
+  db: IDBDatabase,
+  storeName: string,
+  ids: number[]
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    for (const id of ids) {
+      store.delete(id);
+    }
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
 async function getMeta(db: IDBDatabase, key: string): Promise<string | null> {
   return new Promise((resolve, reject) => {
     const tx = db.transaction('meta', 'readonly');
@@ -112,9 +131,11 @@ export async function syncCellarData(): Promise<boolean> {
   try {
     const db = await openDB();
     const lastSync = await getMeta(db, 'last_sync');
+    const syncVersion = await getMeta(db, 'sync_version');
+    const useIncrementalSync = lastSync && syncVersion === SYNC_STATE_VERSION;
 
     let url = '/api/cellar/sync/';
-    if (lastSync) {
+    if (useIncrementalSync) {
       url += `?since=${encodeURIComponent(lastSync)}`;
     }
 
@@ -130,12 +151,16 @@ export async function syncCellarData(): Promise<boolean> {
 
     const data: CellarSyncResponse = await response.json();
     const syncTime = new Date().toISOString();
+    const deletedBeverageIds = data.deleted_beverage_ids ?? [];
+    const deletedStockItemIds = data.deleted_stock_item_ids ?? [];
 
     if (data.is_incremental) {
       // Incremental: merge new/updated records
       await putAll(db, 'beverages', data.beverages);
       await putAll(db, 'stock_items', data.stock_items);
       await putAll(db, 'storages', data.storages);
+      await deleteAll(db, 'beverages', deletedBeverageIds);
+      await deleteAll(db, 'stock_items', deletedStockItemIds);
     } else {
       // Full sync: replace everything
       await clearAndPutAll(db, 'beverages', data.beverages);
@@ -146,6 +171,7 @@ export async function syncCellarData(): Promise<boolean> {
     await setMeta(db, 'last_sync', syncTime);
     await setMeta(db, 'app_type', data.app_type);
     await setMeta(db, 'currency', data.currency);
+    await setMeta(db, 'sync_version', SYNC_STATE_VERSION);
 
     db.close();
     return true;


### PR DESCRIPTION
Summary:
- return deleted beverage and bottle ids from incremental cellar sync responses
- remove tombstoned rows from IndexedDB and force one full refresh after deploy
- update soft-delete paths to refresh modified timestamps so incremental sync picks them up

Notes:
- targeted pytest coverage passed for cellar sync, wine bottle consumption, and whisky bottle consumption
- frontend eslint and migration check passed
- make lint was blocked by pre-existing Black drift in untouched test files and a shared dev port 8003 conflict
