### PR TITLE
fix oldest wine link

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -476,9 +476,9 @@ class TestWineDetailView:
 
         assert response.status_code == HTTPStatus.OK
         content = response.content.decode()
-        assert 'data-image-viewer-open' in content
+        assert "data-image-viewer-open" in content
         assert 'id="beverage-image-viewer"' in content
-        assert 'data-image-viewer-zoom-in' in content
+        assert "data-image-viewer-zoom-in" in content
         assert "View Photos" in content
 
     def test_can_add_price_history(self, client, user, wine_factory, source_factory):
@@ -730,6 +730,30 @@ class TestWineListView:
         assert response.context["filter"].data["order"] == "created"
         assert list(response.context["wines"]) == [oldest, newest]
         assert out_of_stock not in response.context["wines"]
+
+    def test_list_ignores_empty_filter_query_params(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        oldest = wine_factory(user=user, name="Oldest", vintage=1998)
+        newest = wine_factory(user=user, name="Newest", vintage=2021)
+        storage_item_factory(wine=oldest, user=user)
+        storage_item_factory(wine=newest, user=user)
+
+        client.force_login(user)
+        response = client.get(
+            reverse("wine-list"),
+            {
+                "search": "",
+                "wine_type": "",
+                "category": "",
+                "vintage": "",
+                "order": "vintage",
+            },
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        assert list(response.context["wines"]) == [oldest, newest]
+        assert response.context["filter"].data["order"] == "vintage"
 
     def test_per_page_parameter(self, client, user, wine_factory):
         for i in range(15):
@@ -1586,3 +1610,11 @@ class TestHomePageView:
         client.force_login(user)
         r = client.get(reverse("homepage"))
         assert r.context["bottles_in_stock"] >= 1
+
+    def test_oldest_and_youngest_links_use_sort_only_urls(self, client, user):
+        client.force_login(user)
+        response = client.get(reverse("homepage"))
+        content = response.content.decode()
+
+        assert f'href="{reverse("wine-list")}?order=vintage"' in content
+        assert f'href="{reverse("wine-list")}?order=-vintage"' in content

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -884,15 +884,38 @@ class BaseListView(RequireHouseholdMixin):
         context["beverage_icon"] = self.beverage_icon
         return context
 
+    @staticmethod
+    def _strip_empty_filter_values(data):
+        if hasattr(data, "getlist") and hasattr(data, "setlist"):
+            for key in list(data.keys()):
+                values = [value for value in data.getlist(key) if value != ""]
+                if values:
+                    data.setlist(key, values)
+                else:
+                    data.pop(key, None)
+            return data
+
+        cleaned_data = {}
+        for key, value in data.items():
+            if isinstance(value, (list, tuple)):
+                filtered_values = [item for item in value if item != ""]
+                if filtered_values:
+                    cleaned_data[key] = filtered_values
+            elif value != "":
+                cleaned_data[key] = value
+        return cleaned_data
+
     def get_filterset_kwargs(self, filterset_class):
         kwargs = super().get_filterset_kwargs(filterset_class)
-        if not self.default_filter_data:
-            return kwargs
         data = kwargs.get("data")
         if data is None:
             data = self.request.GET.copy()
         else:
             data = data.copy()
+        data = self._strip_empty_filter_values(data)
+        if not self.default_filter_data:
+            kwargs["data"] = data
+            return kwargs
         missing_keys = [key for key in self.default_filter_data if key not in data]
         for key in missing_keys:
             data[key] = self.default_filter_data[key]

--- a/wine_cellar/apps/wine/templates/includes/homepage_stats.html
+++ b/wine_cellar/apps/wine/templates/includes/homepage_stats.html
@@ -34,7 +34,7 @@
 </li>
 <li class="stats__card">
     <a class="stats__link"
-       href="{% url 'wine-list' %}?search=&wine_type=&category=&vintage=&order=vintage">
+       href="{% url 'wine-list' %}?order=vintage">
         <i class="fa-solid fa-hourglass-end stats__icon"></i>
         <p class="stats__number">{{ oldest }}</p>
         <h2 class="stats__label">Oldest Wine</h2>
@@ -42,7 +42,7 @@
 </li>
 <li class="stats__card">
     <a class="stats__link"
-       href="{% url 'wine-list' %}?search=&wine_type=&category=&vintage=&order=-vintage">
+       href="{% url 'wine-list' %}?order=-vintage">
         <i class="fa-solid fa-seedling stats__icon"></i>
         <p class="stats__number">{{ youngest }}</p>
         <h2 class="stats__label">Youngest Wine</h2>


### PR DESCRIPTION
## Summary
- stop the homepage oldest/youngest wine cards from sending empty filter params
- strip empty query values before applying list defaults so blank params do not wipe results
- add regression coverage for the homepage links and the empty-param wine list case

## Testing
- venv/bin/py.test tests/test_core_views.py -k 'ignores_empty_filter_query_params or oldest_and_youngest_links_use_sort_only_urls or defaults_to_in_stock_and_oldest_first' --reuse-db
- venv/bin/black --check tests/test_core_views.py wine_cellar/apps/core/views.py
- venv/bin/isort --diff -c tests/test_core_views.py wine_cellar/apps/core/views.py
- venv/bin/flake8 tests/test_core_views.py wine_cellar/apps/core/views.py --exclude migrations,settings

## Notes
- make lint is currently blocked by a pre-existing Black issue in tests/whisky/test_views.py and a local port 8003 conflict during the Docker migration check