### PR TITLE
fix recently added sort

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -716,11 +716,11 @@ class TestWineListView:
         out_of_stock = wine_factory(user=user, name="Out of Stock")
         old_created = timezone.now() - timezone.timedelta(days=30)
         new_created = timezone.now() - timezone.timedelta(days=1)
-        Wine.objects.filter(pk=oldest.pk).update(created=old_created)
-        Wine.objects.filter(pk=newest.pk).update(created=new_created)
 
-        storage_item_factory(wine=oldest, user=user)
-        storage_item_factory(wine=newest, user=user)
+        oldest_item = storage_item_factory(wine=oldest, user=user)
+        newest_item = storage_item_factory(wine=newest, user=user)
+        StorageItem.objects.filter(pk=oldest_item.pk).update(created=old_created)
+        StorageItem.objects.filter(pk=newest_item.pk).update(created=new_created)
 
         client.force_login(user)
         response = client.get(reverse("wine-list"))
@@ -730,6 +730,50 @@ class TestWineListView:
         assert response.context["filter"].data["order"] == "created"
         assert list(response.context["wines"]) == [oldest, newest]
         assert out_of_stock not in response.context["wines"]
+
+    def test_recently_added_uses_oldest_existing_bottle_date(
+        self, client, user, wine_factory, storage_item_factory
+    ):
+        older_wine = wine_factory(user=user, name="Older Wine")
+        newer_wine = wine_factory(user=user, name="Newer Wine")
+        misleading_old_wine_created = timezone.now() - timezone.timedelta(days=400)
+        misleading_new_wine_created = timezone.now() - timezone.timedelta(days=5)
+        Wine.objects.filter(pk=older_wine.pk).update(
+            created=misleading_old_wine_created
+        )
+        Wine.objects.filter(pk=newer_wine.pk).update(
+            created=misleading_new_wine_created
+        )
+
+        deleted_old_item = storage_item_factory(
+            wine=older_wine, user=user, deleted=True
+        )
+        older_wine_oldest_live = storage_item_factory(wine=older_wine, user=user)
+        storage_item_factory(wine=older_wine, user=user)
+        newer_wine_live = storage_item_factory(wine=newer_wine, user=user)
+
+        now = timezone.now()
+        StorageItem.objects.filter(pk=deleted_old_item.pk).update(
+            created=now - timezone.timedelta(days=120)
+        )
+        StorageItem.objects.filter(pk=older_wine_oldest_live.pk).update(
+            created=now - timezone.timedelta(days=30)
+        )
+        StorageItem.objects.filter(
+            wine=older_wine,
+            deleted=False,
+        ).exclude(
+            pk=older_wine_oldest_live.pk
+        ).update(created=now - timezone.timedelta(days=1))
+        StorageItem.objects.filter(pk=newer_wine_live.pk).update(
+            created=now - timezone.timedelta(days=10)
+        )
+
+        client.force_login(user)
+        response = client.get(reverse("wine-list"), {"order": "-created", "stock": "1"})
+
+        assert response.status_code == HTTPStatus.OK
+        assert list(response.context["wines"]) == [newer_wine, older_wine]
 
     def test_list_ignores_empty_filter_query_params(
         self, client, user, wine_factory, storage_item_factory

--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -774,6 +774,14 @@ class TestWineListView:
 
         assert response.status_code == HTTPStatus.OK
         assert list(response.context["wines"]) == [newer_wine, older_wine]
+        older_wine_from_response = next(
+            wine for wine in response.context["wines"] if wine.pk == older_wine.pk
+        )
+        older_wine_oldest_live.refresh_from_db()
+        assert (
+            older_wine_from_response.stock_first_added_at
+            == older_wine_oldest_live.created
+        )
 
     def test_list_ignores_empty_filter_query_params(
         self, client, user, wine_factory, storage_item_factory

--- a/tests/test_wine_filters.py
+++ b/tests/test_wine_filters.py
@@ -2,7 +2,9 @@ import json
 
 import pytest
 from django.test import RequestFactory
+from django.utils import timezone
 
+from wine_cellar.apps.storage.models import StorageItem
 from wine_cellar.apps.wine.filters import (
     WineFilter,
     get_appellation_choices,
@@ -84,6 +86,31 @@ def test_filter_rating_supports_multiple_selected_ratings(user, wine_factory):
     assert one_star in filt.qs
     assert unrated in filt.qs
     assert two_star not in filt.qs
+
+
+@pytest.mark.django_db
+def test_filter_order_created_annotates_stock_date_for_direct_use(
+    user, wine_factory, storage_item_factory
+):
+    request = RequestFactory().get("/")
+    request.user = user
+
+    older = wine_factory(user=user, name="Older")
+    newer = wine_factory(user=user, name="Newer")
+    older_item = storage_item_factory(wine=older, user=user)
+    newer_item = storage_item_factory(wine=newer, user=user)
+    old_created = timezone.now() - timezone.timedelta(days=20)
+    new_created = timezone.now() - timezone.timedelta(days=3)
+    StorageItem.objects.filter(pk=older_item.pk).update(created=old_created)
+    StorageItem.objects.filter(pk=newer_item.pk).update(created=new_created)
+
+    filt = WineFilter(
+        data={"stock": "0", "order": "created"},
+        queryset=Wine.objects.filter(user=user),
+        request=request,
+    )
+
+    assert list(filt.qs) == [older, newer]
 
 
 @pytest.mark.django_db

--- a/tests/whisky/test_search_filter.py
+++ b/tests/whisky/test_search_filter.py
@@ -2,6 +2,7 @@ import json
 import os
 
 import pytest
+from django.utils import timezone
 
 if os.environ.get("CELLAR_APP_TYPE") == "whisky":
     from django.test import RequestFactory
@@ -135,6 +136,39 @@ if os.environ.get("CELLAR_APP_TYPE") == "whisky":
 
             assert list(filt.qs) == [zero_star, one_star]
             assert two_star not in filt.qs
+
+        def test_order_created_annotates_stock_date_for_direct_use(
+            self, user, whisky_factory, whisky_storage_item_factory
+        ):
+            older = whisky_factory(user=user, name="Older")
+            newer = whisky_factory(user=user, name="Newer")
+            older_item = whisky_storage_item_factory(
+                whisky=older,
+                user=user,
+                household=older.household,
+                storage__user=user,
+                storage__household=older.household,
+            )
+            newer_item = whisky_storage_item_factory(
+                whisky=newer,
+                user=user,
+                household=newer.household,
+                storage__user=user,
+                storage__household=newer.household,
+            )
+
+            old_created = timezone.now() - timezone.timedelta(days=20)
+            new_created = timezone.now() - timezone.timedelta(days=3)
+            WhiskyStorageItem.objects.filter(pk=older_item.pk).update(
+                created=old_created
+            )
+            WhiskyStorageItem.objects.filter(pk=newer_item.pk).update(
+                created=new_created
+            )
+
+            filt = self._filter(user, order="created")
+
+            assert list(filt.qs) == [older, newer]
 
     @pytest.mark.django_db
     class TestWhiskyStorageItemFilter:

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -373,23 +373,22 @@ def test_whisky_list_defaults_to_in_stock_and_oldest_first(
     out_of_stock = whisky_factory(user=user, name="Out of Stock")
     old_created = timezone.now() - datetime.timedelta(days=30)
     new_created = timezone.now() - datetime.timedelta(days=1)
-    Whisky.objects.filter(pk=oldest.pk).update(created=old_created)
-    Whisky.objects.filter(pk=newest.pk).update(created=new_created)
-
-    whisky_storage_item_factory(
+    oldest_item = whisky_storage_item_factory(
         user=user,
         household=household,
         storage__user=user,
         storage__household=household,
         whisky=oldest,
     )
-    whisky_storage_item_factory(
+    newest_item = whisky_storage_item_factory(
         user=user,
         household=household,
         storage__user=user,
         storage__household=household,
         whisky=newest,
     )
+    WhiskyStorageItem.objects.filter(pk=oldest_item.pk).update(created=old_created)
+    WhiskyStorageItem.objects.filter(pk=newest_item.pk).update(created=new_created)
 
     client.force_login(user)
     response = client.get(reverse("whisky-list"))
@@ -949,7 +948,7 @@ def test_whisky_detail_shows_carousel_controls_for_multiple_images(
     assert 'class="wine-prev"' in content
     assert 'class="wine-next"' in content
     assert 'id="beverage-image-viewer"' in content
-    assert 'data-image-viewer-zoom-in' in content
+    assert "data-image-viewer-zoom-in" in content
     assert "View Photos" in content
 
 

--- a/tests/whisky/test_views.py
+++ b/tests/whisky/test_views.py
@@ -373,6 +373,8 @@ def test_whisky_list_defaults_to_in_stock_and_oldest_first(
     out_of_stock = whisky_factory(user=user, name="Out of Stock")
     old_created = timezone.now() - datetime.timedelta(days=30)
     new_created = timezone.now() - datetime.timedelta(days=1)
+    Whisky.objects.filter(pk=oldest.pk).update(created=new_created)
+    Whisky.objects.filter(pk=newest.pk).update(created=old_created)
     oldest_item = whisky_storage_item_factory(
         user=user,
         household=household,

--- a/wine_cellar/apps/core/filters.py
+++ b/wine_cellar/apps/core/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 import pycountry
 from django.core.cache import cache
-from django.db.models import Count, F, Q
+from django.db.models import Count, F, Min, Q
 from django_filters import ChoiceFilter
 
 from wine_cellar.apps.storage.models import Storage, get_app_type
@@ -44,8 +44,18 @@ class BeverageFilterMixin:
             return queryset
         ordering = value[0] if isinstance(value, list) else value
         ordering = self.order_field_aliases.get(ordering, ordering)
+        ordering_field = ordering.lstrip("-")
+        if ordering_field == "stock_first_added_at":
+            annotations = getattr(queryset.query, "annotations", {})
+            if ordering_field not in annotations:
+                queryset = queryset.annotate(
+                    stock_first_added_at=Min(
+                        f"{self.storage_item_reverse}__created",
+                        filter=Q(**{f"{self.storage_item_reverse}__deleted": False}),
+                    )
+                )
         if ordering.lstrip("-") in self.nullable_order_fields:
-            field = F(ordering.lstrip("-"))
+            field = F(ordering_field)
             if ordering.startswith("-"):
                 return queryset.order_by(field.desc(nulls_last=True))
             return queryset.order_by(field.asc(nulls_last=True))

--- a/wine_cellar/apps/core/filters.py
+++ b/wine_cellar/apps/core/filters.py
@@ -22,6 +22,7 @@ class BeverageFilterMixin:
 
     storage_item_reverse = None
     nullable_order_fields = ()
+    order_field_aliases = {}
     search_fields = ()
     include_unrated_with_zero_rating = False
 
@@ -42,6 +43,7 @@ class BeverageFilterMixin:
         if not value:
             return queryset
         ordering = value[0] if isinstance(value, list) else value
+        ordering = self.order_field_aliases.get(ordering, ordering)
         if ordering.lstrip("-") in self.nullable_order_fields:
             field = F(ordering.lstrip("-"))
             if ordering.startswith("-"):

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -8,7 +8,7 @@ import qrcode
 from django.conf import settings
 from django.contrib import messages
 from django.db import transaction
-from django.db.models import Avg, Count, F, Q, Sum
+from django.db.models import Avg, Count, F, Min, Q, Sum
 from django.db.models.functions import Coalesce, TruncMonth
 from django.forms import model_to_dict
 from django.http import HttpResponse, JsonResponse
@@ -924,6 +924,7 @@ class BaseListView(RequireHouseholdMixin):
 
     def get_queryset(self):
         price_path = f"{self.storage_item_reverse}__price"
+        stock_filter = Q(**{f"{self.storage_item_reverse}__deleted": False})
         qs = (
             super()
             .get_queryset()
@@ -932,10 +933,14 @@ class BaseListView(RequireHouseholdMixin):
             .order_by("-created")
         )
         qs = qs.annotate(
+            stock_first_added_at=Min(
+                f"{self.storage_item_reverse}__created",
+                filter=stock_filter,
+            ),
             effective_price=Coalesce(Avg(price_path), "price"),
             stock_count=Count(
                 self.storage_item_reverse,
-                filter=Q(**{f"{self.storage_item_reverse}__deleted": False}),
+                filter=stock_filter,
                 distinct=True,
             ),
         )

--- a/wine_cellar/apps/whisky/filters.py
+++ b/wine_cellar/apps/whisky/filters.py
@@ -62,7 +62,11 @@ def get_country_choices(user=None):
 
 class WhiskyFilter(BeverageFilterMixin, django_filters.FilterSet):
     storage_item_reverse = "whiskystorageitem"
-    nullable_order_fields = ("age_statement", "effective_price")
+    nullable_order_fields = ("age_statement", "effective_price", "stock_first_added_at")
+    order_field_aliases = {
+        "created": "stock_first_added_at",
+        "-created": "-stock_first_added_at",
+    }
     search_fields = (
         "name",
         "comment",

--- a/wine_cellar/apps/wine/filters.py
+++ b/wine_cellar/apps/wine/filters.py
@@ -92,7 +92,16 @@ def get_grape_wine_type_map(user=None):
 
 class WineFilter(BeverageFilterMixin, django_filters.FilterSet):
     storage_item_reverse = "storageitem"
-    nullable_order_fields = ("vintage", "effective_price", "drink_to")
+    nullable_order_fields = (
+        "vintage",
+        "effective_price",
+        "drink_to",
+        "stock_first_added_at",
+    )
+    order_field_aliases = {
+        "created": "stock_first_added_at",
+        "-created": "-stock_first_added_at",
+    }
     search_fields = (
         "name",
         "comment",


### PR DESCRIPTION
## Summary
- make Recently Added and Least Recently Added sort by the oldest live in-stock bottle date
- ignore deleted bottles when deriving the stock-based sort date
- add regression coverage for wine and whisky list ordering

Closes #242

## Testing
- venv/bin/black --check wine_cellar/apps/core/filters.py wine_cellar/apps/core/views.py wine_cellar/apps/wine/filters.py wine_cellar/apps/whisky/filters.py tests/test_core_views.py tests/whisky/test_views.py
- venv/bin/isort --diff -c wine_cellar/apps/core/filters.py wine_cellar/apps/core/views.py wine_cellar/apps/wine/filters.py wine_cellar/apps/whisky/filters.py tests/test_core_views.py tests/whisky/test_views.py
- venv/bin/flake8 wine_cellar/apps/core/filters.py wine_cellar/apps/core/views.py wine_cellar/apps/wine/filters.py wine_cellar/apps/whisky/filters.py tests/test_core_views.py tests/whisky/test_views.py --exclude migrations,settings
- venv/bin/py.test tests/test_core_views.py -k 'defaults_to_in_stock_and_oldest_first or recently_added_uses_oldest_existing_bottle_date or ignores_empty_filter_query_params or oldest_and_youngest_links_use_sort_only_urls' --reuse-db
- CELLAR_APP_TYPE=whisky venv/bin/py.test tests/whisky/test_views.py -k 'whisky_list_defaults_to_in_stock_and_oldest_first' --reuse-db