### PR TITLE
fix flaky grape factory uniqueness

### DIFF
--- a/wine_cellar/apps/wine/tests/factories.py
+++ b/wine_cellar/apps/wine/tests/factories.py
@@ -32,7 +32,7 @@ class GrapeFactory(DjangoModelFactory):
     class Meta:
         model = Grape
 
-    name = factory.Faker("name")
+    name = factory.Sequence(lambda n: f"Grape {n}")
     # user and household are nullable - only set if explicitly passed
 
 


### PR DESCRIPTION
## Summary
- make GrapeFactory names deterministic and unique with factory.Sequence
- prevent intermittent test collisions against the Grape (name, user) uniqueness constraint
- stabilize the per_page CI failure seen in PR #241

## Testing
- venv/bin/flake8 wine_cellar/apps/wine/tests/factories.py
- repeated tests/test_core_views.py::TestWineListView::test_per_page_parameter 10 times