### PR TITLE
include added wines in recently viewed

### DIFF
--- a/tests/test_core_views.py
+++ b/tests/test_core_views.py
@@ -1655,6 +1655,30 @@ class TestHomePageView:
         assert r.status_code == HTTPStatus.OK
         assert "bottles_in_stock" in r.context
 
+    def test_newly_added_wine_appears_in_recent_views(self, client, user):
+        client.force_login(user)
+
+        response = client.post(
+            reverse("wine-add"),
+            {
+                "name": "Fresh Add",
+                "wine_type": WineType.RED,
+                "country": "FR",
+                "form_step": 0,
+            },
+            follow=True,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        wine = Wine.objects.get(name="Fresh Add")
+        session = client.session
+        assert session["recent_views"][0]["pk"] == wine.pk
+
+        homepage = client.get(reverse("homepage"))
+
+        assert homepage.status_code == HTTPStatus.OK
+        assert list(homepage.context["recent_views"]) == [wine]
+
     def test_shows_stats(self, client, user, wine_factory, storage_item_factory):
         wine = wine_factory(user=user, price=Decimal("20.00"))
         storage = user.storage_set.first()

--- a/wine_cellar/apps/core/views.py
+++ b/wine_cellar/apps/core/views.py
@@ -1775,6 +1775,8 @@ class BaseBeverageCreateView(RequireMemberMixin, FormView):
         for key in ("scanned_label", "extraction_result"):
             self.request.session.pop(key, None)
 
+        _track_recent_view(self.request, beverage)
+
         if not created:
             from django.contrib import messages
 


### PR DESCRIPTION
## Summary
- add newly created beverages to the recent views session list
- show newly added wines in the homepage Recently Viewed widget without a detail-page visit
- add regression coverage for the wine add flow

Closes #238

## Testing
- venv/bin/flake8 wine_cellar/apps/core/views.py tests/test_core_views.py
- venv/bin/py.test tests/test_core_views.py::TestWineDetailView::test_tracks_recent_view_in_session tests/test_core_views.py::TestHomePageView::test_newly_added_wine_appears_in_recent_views --reuse-db -q